### PR TITLE
Fix hooks order violation in authenticated layout

### DIFF
--- a/web/apps/checkout/src/routes/_authenticated.tsx
+++ b/web/apps/checkout/src/routes/_authenticated.tsx
@@ -17,6 +17,9 @@ function AuthenticatedLayout() {
   const { user, userDoc, loading, userDocLoading, signOut } = useAuth()
   const navigate = useNavigate()
   const matches = useMatches()
+  // Hooks must be called unconditionally before any early returns
+  const isMobile = useIsMobile()
+  const [sheetOpen, setSheetOpen] = useState(false)
 
   // Redirect to login if not authenticated
   useEffect(() => {
@@ -43,9 +46,6 @@ function AuthenticatedLayout() {
   }
 
   if (!user) return null
-
-  const isMobile = useIsMobile()
-  const [sheetOpen, setSheetOpen] = useState(false)
 
   const navLink = "flex items-center gap-2.5 px-3 py-2 rounded-[3px] text-sm transition-colors"
   const navLinkActive = "[&.active]:bg-cog-teal [&.active]:text-white [&.active]:font-semibold"


### PR DESCRIPTION
## Summary

- Moves `useIsMobile()` and `useState(false)` before the early returns in `AuthenticatedLayout`
- Hooks are now called unconditionally on every render, satisfying React's rules of hooks
- Prevents the "Rendered more hooks than during the previous render" error when navigating to `/visit` directly or refreshing while unauthenticated

## Test plan

- [x] TypeScript build passes
- [x] Web unit tests pass (195 tests)
- [x] Web integration tests pass (15 tests)
- [x] Functions unit + integration tests pass

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)