### PR TITLE
Auto-scroll to article search dropdown on open

### DIFF
--- a/web/apps/checkout/src/components/usage/inline-rows.tsx
+++ b/web/apps/checkout/src/components/usage/inline-rows.tsx
@@ -794,6 +794,8 @@ function AddArticleSearch({
 
   useEffect(() => {
     inputRef.current?.focus()
+    // Scroll the container into view so the dropdown is visible
+    containerRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
   }, [])
 
   // Close on outside click


### PR DESCRIPTION
## Summary

- Adds `scrollIntoView({ behavior: "smooth", block: "start" })` to the existing `useEffect` in `AddArticleSearch` so the search input scrolls to the top of the viewport when the component mounts
- Ensures the dropdown results are fully visible on mobile without requiring manual scrolling

## Test plan

- [ ] Open a checkout session with article items
- [ ] Tap "Artikel hinzufügen" on a mobile viewport (or narrow browser window)
- [ ] Verify the search input smoothly scrolls to the top of the viewport
- [ ] Verify the dropdown results appear below without being clipped

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)