### PR TITLE
fix(checkout): hide login/signup switch after sign-in link sent

### DIFF
--- a/web/apps/checkout/e2e/signup.spec.ts
+++ b/web/apps/checkout/e2e/signup.spec.ts
@@ -15,6 +15,11 @@ test.describe("Self-registration", () => {
   test("new user signs up, completes profile, and has no roles", async ({ page }) => {
     // ── Sign in via /login with a fresh email ──
     await page.goto("/login")
+
+    // On the signup page (or login page), the switch link is visible while the
+    // form is shown.
+    await expect(page.getByText("Noch kein Konto?")).toBeVisible()
+
     await page.getByPlaceholder("deine@email.ch").fill(SIGNUP_EMAIL)
     await page
       .getByRole("button", { name: "Anmelde-Link senden" })
@@ -23,6 +28,12 @@ test.describe("Self-registration", () => {
     await expect(
       page.getByText("Anmelde-Link wurde an"),
     ).toBeVisible({ timeout: 5000 })
+
+    // Regression (#103): the account-switch link must disappear once the
+    // sign-in link has been sent — it's confusing to offer "Bereits
+    // registriert? Anmelden" on the confirmation screen.
+    await expect(page.getByText("Bereits registriert?")).not.toBeVisible()
+    await expect(page.getByText("Noch kein Konto?")).not.toBeVisible()
 
     // Fetch sign-in link from Auth emulator
     const signInCode = await waitForOobCode(
@@ -91,10 +102,17 @@ test.describe("Self-registration", () => {
     await page.waitForURL((url) => url.pathname === "/login", { timeout: 5_000 })
     await expect(page.getByText("Konto erstellen")).toBeVisible()
 
+    // In signup mode, the "already registered" switch link is visible.
+    await expect(page.getByText("Bereits registriert?")).toBeVisible()
+
     // ── Send sign-in link ──
     await page.getByPlaceholder("deine@email.ch").fill(CHECKOUT_SIGNUP_EMAIL)
     await page.getByRole("button", { name: "Anmelde-Link senden" }).click()
     await expect(page.getByText("Anmelde-Link wurde an")).toBeVisible({ timeout: 5_000 })
+
+    // Regression (#103): once the link has been sent, the "Bereits
+    // registriert? Anmelden" switch link must no longer be shown.
+    await expect(page.getByText("Bereits registriert?")).not.toBeVisible()
 
     // ── Complete email link sign-in ──
     const signInCode = await waitForOobCode(

--- a/web/apps/checkout/src/routes/login.tsx
+++ b/web/apps/checkout/src/routes/login.tsx
@@ -196,29 +196,31 @@ function LoginPage() {
             </>
           )}
 
-          <div className="text-center text-sm text-muted-foreground">
-            {isSignup ? (
-              <>
-                Bereits registriert?{" "}
-                <a
-                  href={`/login${redirectTo ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`}
-                  className="text-cog-teal hover:underline"
-                >
-                  Anmelden
-                </a>
-              </>
-            ) : (
-              <>
-                Noch kein Konto?{" "}
-                <a
-                  href={`/login?mode=signup${redirectTo ? `&redirect=${encodeURIComponent(redirectTo)}` : ""}`}
-                  className="text-cog-teal hover:underline"
-                >
-                  Konto erstellen
-                </a>
-              </>
-            )}
-          </div>
+          {!linkSent && (
+            <div className="text-center text-sm text-muted-foreground">
+              {isSignup ? (
+                <>
+                  Bereits registriert?{" "}
+                  <a
+                    href={`/login${redirectTo ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`}
+                    className="text-cog-teal hover:underline"
+                  >
+                    Anmelden
+                  </a>
+                </>
+              ) : (
+                <>
+                  Noch kein Konto?{" "}
+                  <a
+                    href={`/login?mode=signup${redirectTo ? `&redirect=${encodeURIComponent(redirectTo)}` : ""}`}
+                    className="text-cog-teal hover:underline"
+                  >
+                    Konto erstellen
+                  </a>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- On the `/login` page, the "Bereits registriert? Anmelden" / "Noch kein Konto? Konto erstellen" switch link was shown even after the user submitted the form and the confirmation screen ("Anmelde-Link wurde an…") was displayed.
- Wraps the switch block in `{!linkSent && …}` in `web/apps/checkout/src/routes/login.tsx` so it disappears once the magic link is sent.

Closes #103

## Regression coverage
`web/apps/checkout/e2e/signup.spec.ts`:
- Asserts the `"Noch kein Konto?"` / `"Bereits registriert?"` switch link is visible while the form is shown.
- Asserts the switch link is no longer visible once `"Anmelde-Link wurde an"` appears.

Covers both the `/login` (default) and `/login?mode=signup` entry points.

## Test results
- `npm run test:precommit` → passes.
- `firebase emulators:exec … 'npx playwright test signup'` → all 4 signup e2e tests pass, including the two new regression assertions.
- Full `npm run test:web:e2e` run shows 10 pre-existing failures unrelated to this change (the failing tests all block on `getByText('Abmelden')` after sign-in — introduced earlier by `933a958` / #107 work, not by this PR).

---
🤖 Automated by `/workqueue`