### PR TITLE
Fix UI issues when adding item in checkout

### DIFF
--- a/web/apps/checkout/src/components/checkout/step-workshops.browser.test.tsx
+++ b/web/apps/checkout/src/components/checkout/step-workshops.browser.test.tsx
@@ -1,0 +1,162 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+import { render, screen, cleanup } from "@testing-library/react"
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest"
+import { useReducer, type ReactNode } from "react"
+import { FirebaseProvider, type FirebaseServices } from "@modules/lib/firebase-context"
+import type { PricingConfig, WorkshopId } from "@modules/lib/workshop-config"
+import type { CheckoutItemLocal } from "@/components/usage/inline-rows"
+
+// Stub the catalog-loading child component to avoid touching Firestore. The
+// stub renders a recognisable marker so we can assert the per-workshop section
+// was mounted.
+vi.mock("@/components/usage/workshop-section-with-catalog", () => ({
+  WorkshopSectionWithCatalog: ({ workshopId }: { workshopId: string }) => (
+    <div data-testid={`workshop-section-${workshopId}`}>
+      Section for {workshopId}
+    </div>
+  ),
+}))
+
+import { StepWorkshops } from "./step-workshops"
+import {
+  checkoutReducer,
+  initialState,
+  type CheckoutState,
+} from "./use-checkout-state"
+
+afterEach(cleanup)
+
+function makeConfig(): PricingConfig {
+  return {
+    entryFees: { erwachsen: {}, kind: {}, firma: {} },
+    workshops: {
+      holz: { label: "Holz", order: 1 },
+      makerspace: { label: "Maker Space", order: 2 },
+    } as PricingConfig["workshops"],
+    labels: {
+      units: { h: "Std.", m2: "m²", m: "m", stk: "Stk.", kg: "kg", chf: "CHF" },
+      discounts: { none: "Normal", member: "Mitglied", intern: "Intern" },
+    },
+  }
+}
+
+function makeItem(overrides: Partial<CheckoutItemLocal> = {}): CheckoutItemLocal {
+  return {
+    id: "item-1",
+    workshop: "makerspace",
+    description: "Filament PLA",
+    origin: "manual",
+    catalogId: "cat-filament",
+    pricingModel: "weight",
+    quantity: 1,
+    unitPrice: 50,
+    totalPrice: 50,
+    ...overrides,
+  }
+}
+
+function FirebaseWrapper({ children }: { children: ReactNode }) {
+  const services: FirebaseServices = {
+    db: {} as FirebaseServices["db"],
+    auth: {} as FirebaseServices["auth"],
+    functions: {} as FirebaseServices["functions"],
+  }
+  return <FirebaseProvider value={services}>{children}</FirebaseProvider>
+}
+
+/**
+ * Renders StepWorkshops with a reducer so dispatch actually mutates state, and
+ * lets the caller rerender with updated items (simulating Firestore snapshots
+ * landing after mount). Returns handles to the rerender function.
+ */
+function renderStepWorkshops(initialItems: CheckoutItemLocal[] = []) {
+  let currentItems = initialItems
+  const setItems = (next: CheckoutItemLocal[]) => {
+    currentItems = next
+    result.rerender(<Wrapper />)
+  }
+
+  function Wrapper() {
+    const init: CheckoutState = { ...initialState, step: 1 }
+    const [state, dispatch] = useReducer(checkoutReducer, init)
+    return (
+      <FirebaseWrapper>
+        <StepWorkshops
+          state={state}
+          dispatch={dispatch}
+          isAnonymous={false}
+          config={makeConfig()}
+          items={currentItems}
+          checkoutId="co-123"
+          userRef={null}
+          discountLevel="none"
+        />
+      </FirebaseWrapper>
+    )
+  }
+
+  const result = render(<Wrapper />)
+  return { setItems }
+}
+
+describe("StepWorkshops: workshop with items stays selected across prop changes (issue #99)", () => {
+  beforeEach(() => {
+    // StepWorkshops reads window.matchMedia via useIsMobile — stub it so the
+    // hook resolves to a definite value in the browser test environment.
+    if (!window.matchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        })),
+      })
+    }
+  })
+
+  it("renders the workshop section when items arrive after mount", () => {
+    // Initial render with no items — this is what happens right after
+    // StepWorkshops re-mounts because `checkoutId` changed when the first item
+    // was added (the Firestore items subscription hasn't delivered its first
+    // snapshot yet).
+    const { setItems } = renderStepWorkshops([])
+
+    // No workshop section visible yet.
+    expect(screen.queryByTestId("workshop-section-makerspace")).toBeNull()
+
+    // Firestore snapshot lands a tick later — the checkout now has an item
+    // for the makerspace.
+    setItems([makeItem({ id: "i1", workshop: "makerspace" as WorkshopId })])
+
+    // The Maker Space section must be rendered even though the user never
+    // clicked the checkbox after this mount — `workshopsWithItems` is derived
+    // from `items` and must flow into `selectedWorkshops`.
+    expect(screen.getByTestId("workshop-section-makerspace")).toBeTruthy()
+  })
+
+  it("renders the workshop section when the component mounts with items already present", () => {
+    // Sanity check: a fresh mount with items present (e.g. after reloading
+    // the page) still shows the section. The reporter noted reloading fixes
+    // the bug — this asserts we haven't regressed that path.
+    renderStepWorkshops([makeItem({ id: "i1", workshop: "makerspace" as WorkshopId })])
+
+    expect(screen.getByTestId("workshop-section-makerspace")).toBeTruthy()
+  })
+
+  it("Maker Space checkbox is checked and disabled when items exist for it", () => {
+    renderStepWorkshops([makeItem({ id: "i1", workshop: "makerspace" as WorkshopId })])
+
+    // Find the Maker Space checkbox via its label text.
+    const label = screen.getByText("Maker Space").closest("label")
+    expect(label).toBeTruthy()
+    const checkbox = label!.querySelector('button[role="checkbox"]') as HTMLButtonElement
+    expect(checkbox).toBeTruthy()
+    expect(checkbox.getAttribute("data-state")).toBe("checked")
+    expect(checkbox.getAttribute("data-disabled")).not.toBeNull()
+  })
+})

--- a/web/apps/checkout/src/components/checkout/step-workshops.tsx
+++ b/web/apps/checkout/src/components/checkout/step-workshops.tsx
@@ -78,14 +78,24 @@ export function StepWorkshops({
     return s
   }, [items])
 
-  // Pre-select workshops that have items
-  const [selectedWorkshops, setSelectedWorkshops] = useState<Set<WorkshopId>>(
-    () => new Set<WorkshopId>(workshopsWithItems),
-  )
+  // Track checkbox toggles explicitly made by the user. Workshops that already
+  // have items are always considered selected (derived below); keeping manual
+  // selections separate avoids snapshot drift when `items` arrives late (e.g.
+  // after a StepWorkshops re-mount triggered by `checkoutId` changing when the
+  // first item is added). See issue #99.
+  const [manuallySelectedWorkshops, setManuallySelectedWorkshops] = useState<
+    Set<WorkshopId>
+  >(() => new Set<WorkshopId>())
+
+  const selectedWorkshops = useMemo(() => {
+    const combined = new Set<WorkshopId>(manuallySelectedWorkshops)
+    for (const wsId of workshopsWithItems) combined.add(wsId)
+    return combined
+  }, [manuallySelectedWorkshops, workshopsWithItems])
 
   const toggleWorkshop = (wsId: WorkshopId) => {
     if (workshopsWithItems.has(wsId)) return
-    setSelectedWorkshops((prev) => {
+    setManuallySelectedWorkshops((prev) => {
       const next = new Set(prev)
       if (next.has(wsId)) {
         next.delete(wsId)


### PR DESCRIPTION
## Summary
- Adding the first item to a Maker Space checkout momentarily re-mounts `StepWorkshops` because `checkoutId` changes as the parent checkout doc is created, flipping `loadingItems` back to `true`.
- On re-mount, the `selectedWorkshops` `useState` initializer snapshotted an empty items array (Firestore listener hadn't delivered yet), so the per-workshop inline section never rendered even after items landed — producing the reported "Makerspace appears selected but greyed out, no field displayed" symptom.
- Derive `selectedWorkshops` via `useMemo` as the union of user-toggled workshops and `workshopsWithItems` so the section is always visible when items exist, regardless of load timing.

Fixes #99

## Test plan
- [x] New browser unit test `step-workshops.browser.test.tsx` (3 cases): section renders when items arrive after mount, section renders when items are present at mount, checkbox is checked-and-disabled for workshops with items. The "items after mount" case was verified to fail against the old buggy code.
- [x] `npm run test:precommit` — all green.
- [x] `npm run test:browser` — 56 tests pass (including the 3 new ones).
- [x] `npm run test:web:e2e` — all 54 E2E tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)