### PR TITLE
fix(tests): deflake isSessionExpired across midnight boundary

### DIFF
--- a/functions/src/util/session_expiration.test.ts
+++ b/functions/src/util/session_expiration.test.ts
@@ -124,12 +124,13 @@ describe("Session Expiration", () => {
     });
 
     it("should return true for a session that has expired", () => {
-      // Create a session that started yesterday at 10 AM
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-      yesterday.setHours(10, 0, 0, 0);
-      const startTime = Timestamp.fromDate(yesterday);
-      
+      // 48 hours ago — expiration is always at least a full day in the past,
+      // regardless of the current wall-clock time. A "yesterday 10 AM" anchor
+      // failed between 00:00–03:00 local because expiration (3 AM today) was
+      // still in the future.
+      const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+      const startTime = Timestamp.fromDate(twoDaysAgo);
+
       expect(isSessionExpired(startTime)).to.equal(true);
     });
 


### PR DESCRIPTION
## Summary
The `isSessionExpired > should return true for a session that has expired` test used a "yesterday at 10 AM" anchor, whose expiration (3 AM today) is still in the future when the test runs between 00:00 and 03:00 local. This made `/workqueue` runs after midnight abort in Phase 0. Switch to a 48-hour offset so the expiration is always well in the past.

## Test plan
- [x] `cd functions && node_modules/.bin/mocha 'lib/src/util/session_expiration.test.js'` — 14/14 pass
- [x] `npm run test:precommit` — green (91 + 24 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)