### PR TITLE
fix(functions): bump mocha root before-hook timeout for visual tests

### DIFF
--- a/functions/test/unit/build_invoice_pdf.visual.test.ts
+++ b/functions/test/unit/build_invoice_pdf.visual.test.ts
@@ -32,7 +32,10 @@ let pdfToImg: any;
 let pixelmatch: any;
 let PNG: any;
 
-before(async () => {
+before(async function () {
+  // Cold-start ESM imports of pdf-to-img/pixelmatch/pngjs can exceed mocha's
+  // 2s default on CI runners; bump the hook timeout so it doesn't flake.
+  this.timeout(5_000);
   const pdfModule = await import("pdf-to-img");
   pdfToImg = pdfModule.pdf;
   const pmModule = await import("pixelmatch");

--- a/functions/test/unit/build_price_list_pdf.visual.test.ts
+++ b/functions/test/unit/build_price_list_pdf.visual.test.ts
@@ -32,7 +32,10 @@ let pdfToImg: any;
 let pixelmatch: any;
 let PNG: any;
 
-before(async () => {
+before(async function () {
+  // Cold-start ESM imports of pdf-to-img/pixelmatch/pngjs can exceed mocha's
+  // 2s default on CI runners; bump the hook timeout so it doesn't flake.
+  this.timeout(5_000);
   const pdfModule = await import("pdf-to-img");
   pdfToImg = pdfModule.pdf;
   const pmModule = await import("pixelmatch");


### PR DESCRIPTION
## Summary
- The root `before()` hook in `build_invoice_pdf.visual.test.ts` and `build_price_list_pdf.visual.test.ts` dynamically imports three ESM-only deps (`pdf-to-img`, `pixelmatch`, `pngjs`). On cold CI runners that occasionally exceeds mocha's 2s default and times out as `"before all" hook in {root}`, failing the unit-test step with `0 passing / 1 failing`.
- Bump the per-hook timeout to 5s. This is the root cause of the flake seen on PR #183's Tests run.

## Test plan
- [x] `cd functions && npm run test:unit` passes locally (153 tests)
- [x] `npm run test:precommit` passes (pre-commit hook ran during commit)
- [ ] CI Tests workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)