### PR TITLE
fix(checkout): Spende input accepts trailing digits like 0

### DIFF
--- a/web/apps/checkout/src/components/checkout/step-checkout-spende.test.tsx
+++ b/web/apps/checkout/src/components/checkout/step-checkout-spende.test.tsx
@@ -1,0 +1,96 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+import { render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { useState } from "react"
+import { SpendeCard } from "./step-checkout"
+
+afterEach(cleanup)
+
+/**
+ * Wrapper that mirrors the parent's `manualTip` numeric state, so we exercise
+ * the same controlled-input contract `StepCheckout` uses.
+ */
+function Harness({ onChange }: { onChange?: (v: number) => void }) {
+  const [spende, setSpende] = useState(0)
+  return (
+    <SpendeCard
+      spende={spende}
+      onSpendeChange={(v) => {
+        setSpende(v)
+        onChange?.(v)
+      }}
+      roundUpEnabled={false}
+      roundUpOptions={[]}
+      roundUpTarget={null}
+      roundUpDelta={0}
+      onRoundUpToggle={() => {}}
+      onRoundUpTarget={() => {}}
+    />
+  )
+}
+
+describe("SpendeCard input", () => {
+  it("accepts trailing digits like '20' without truncating to '2'", async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Harness onChange={onChange} />)
+
+    const input = screen.getByLabelText("Trinkgeld/Spende") as HTMLInputElement
+    await user.type(input, "20")
+
+    // The bug: previous behaviour reformatted "2" -> "2.00" on each
+    // keystroke, blocking the "0".
+    expect(input.value).toBe("20")
+    expect(onChange).toHaveBeenLastCalledWith(20)
+  })
+
+  it("accepts a decimal point and partial fraction during typing", async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Harness onChange={onChange} />)
+
+    const input = screen.getByLabelText("Trinkgeld/Spende") as HTMLInputElement
+    await user.type(input, "0.5")
+
+    expect(input.value).toBe("0.5")
+    expect(onChange).toHaveBeenLastCalledWith(0.5)
+  })
+
+  it("normalizes to two decimals on blur", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const input = screen.getByLabelText("Trinkgeld/Spende") as HTMLInputElement
+    await user.type(input, "20")
+    expect(input.value).toBe("20")
+
+    // Tab away to trigger blur.
+    await user.tab()
+    expect(input.value).toBe("20.00")
+  })
+
+  it("accepts comma as decimal separator", async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Harness onChange={onChange} />)
+
+    const input = screen.getByLabelText("Trinkgeld/Spende") as HTMLInputElement
+    await user.type(input, "1,5")
+
+    expect(input.value).toBe("1,5")
+    expect(onChange).toHaveBeenLastCalledWith(1.5)
+  })
+
+  it("clears to empty on blur when value is zero", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const input = screen.getByLabelText("Trinkgeld/Spende") as HTMLInputElement
+    await user.type(input, "0")
+    await user.tab()
+    expect(input.value).toBe("")
+  })
+})

--- a/web/apps/checkout/src/components/checkout/step-checkout.tsx
+++ b/web/apps/checkout/src/components/checkout/step-checkout.tsx
@@ -1,7 +1,7 @@
 // Copyright Offene Werkstatt Wädenswil
 // SPDX-License-Identifier: MIT
 
-import { useState, useMemo, useCallback } from "react"
+import { useState, useMemo, useCallback, useEffect, useRef } from "react"
 import { Label } from "@modules/components/ui/label"
 import { Separator } from "@modules/components/ui/separator"
 import { formatCHF } from "@modules/lib/format"
@@ -633,7 +633,12 @@ interface SpendeCardProps {
   onRoundUpTarget: (target: number) => void
 }
 
-function SpendeCard({
+/** Permissive numeric pattern accepted while typing: digits with at most one
+ *  `.` or `,` separator. Empty string is also accepted so the field can be
+ *  fully cleared. */
+const SPENDE_TYPING_PATTERN = /^(?:|\d*(?:[.,]\d*)?)$/
+
+export function SpendeCard({
   spende,
   onSpendeChange,
   roundUpEnabled,
@@ -643,6 +648,24 @@ function SpendeCard({
   onRoundUpToggle,
   onRoundUpTarget,
 }: SpendeCardProps) {
+  // Raw text the user is typing. Decoupled from `spende` so a keystroke like
+  // "20" survives the parse-and-reformat round-trip that previously stripped
+  // trailing zeros.
+  const [text, setText] = useState(() => (spende > 0 ? spende.toFixed(2) : ""))
+  const focusedRef = useRef(false)
+
+  // Sync from external `spende` only while the field is unfocused. This keeps
+  // the displayed text canonical when the parent updates `spende` (rare today
+  // but cheap to be safe), without clobbering mid-typing input.
+  useEffect(() => {
+    if (focusedRef.current) return
+    const canonical = spende > 0 ? spende.toFixed(2) : ""
+    // Avoid spurious updates when the existing text already parses to the
+    // same value (e.g. "20" vs "20.00" while focused-then-blurred elsewhere).
+    const parsed = parseFloat(text.replace(",", ".")) || 0
+    if (parsed !== spende) setText(canonical)
+  }, [spende, text])
+
   return (
     <div className="rounded-md border border-oww-gold-border bg-oww-gold-light p-5 sm:p-6 grid sm:grid-cols-[1fr_auto] gap-4 sm:gap-6 items-start">
       <div className="min-w-0">
@@ -666,10 +689,22 @@ function SpendeCard({
             type="text"
             inputMode="decimal"
             placeholder="0.00"
-            value={spende > 0 ? spende.toFixed(2) : ""}
+            value={text}
+            onFocus={() => {
+              focusedRef.current = true
+            }}
             onChange={(e) => {
-              const v = parseFloat(e.target.value.replace(",", ".")) || 0
+              const raw = e.target.value
+              if (!SPENDE_TYPING_PATTERN.test(raw)) return
+              setText(raw)
+              const v = parseFloat(raw.replace(",", ".")) || 0
               onSpendeChange(v)
+            }}
+            onBlur={() => {
+              focusedRef.current = false
+              const v = parseFloat(text.replace(",", ".")) || 0
+              setText(v > 0 ? v.toFixed(2) : "")
+              if (v !== spende) onSpendeChange(v)
             }}
             aria-label="Trinkgeld/Spende"
             className="w-[140px] h-11 pl-12 pr-3.5 rounded-md border border-oww-gold-border bg-background text-base font-semibold tabular-nums text-oww-gold-text text-right placeholder:text-oww-gold-border placeholder:font-normal focus:outline-none focus:border-oww-gold-dark focus:ring-2 focus:ring-oww-gold-dark/20"


### PR DESCRIPTION
## Summary
- The Trinkgeld/Spende input on the checkout summary previously derived its `value` from `spende.toFixed(2)` on every keystroke. Typing "20" produced "2" -> "2.00", and the trailing "0" was rejected.
- `SpendeCard` now keeps raw text state, parses for live totals on change, and only normalizes to two decimals on blur. Comma is still accepted as a decimal separator.

Closes #205

## Regression coverage
- `web/apps/checkout/src/components/checkout/step-checkout-spende.test.tsx` (new) covers the exact bug:
  - Typing "20" leaves displayed value as "20" (not "2.00") and reports `20` to the parent.
  - Typing "0.5" mid-stream is preserved; parent sees `0.5`.
  - Blur normalizes "20" to "20.00" and zero values clear to empty.
  - Comma decimal separator still works.
- `npm run test:precommit` and `npm run test:web:e2e` both green; no screenshot baselines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)