### PR TITLE
fix(functions): add loginCodes (email, created asc) index

### DIFF
--- a/firestore/firestore.indexes.json
+++ b/firestore/firestore.indexes.json
@@ -155,6 +155,20 @@
       ]
     },
     {
+      "collectionGroup": "loginCodes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "email",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "memberships",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/src/auth/login-code/request.ts
+++ b/functions/src/auth/login-code/request.ts
@@ -120,8 +120,9 @@ export async function handleRequestLoginCode(
 
   // Per-email 24h cap on code requests (issue #152). Brute-force defence:
   // an attacker rotating fresh codes past the 60s throttle would otherwise
-  // get unbounded attempts at one address. The existing
-  // (email asc, created desc) index supports this query — no new index.
+  // get unbounded attempts at one address. The inequality on `created`
+  // needs an (email asc, created asc) composite index — distinct from the
+  // (email asc, created desc) index used by the latest-doc lookup above.
   const perEmailWindowMs = parseIntParamOrDie(
     "LOGIN_PER_EMAIL_WINDOW_MS",
     perEmailWindowMsParam.value()


### PR DESCRIPTION
The per-email 24h cap in requestLoginCode uses an inequality on `created`, which requires (email asc, created asc) — distinct from the existing (email asc, created desc) index. Prior comment claimed they shared an index; that was wrong and surfaced as a FAILED_PRECONDITION in production.