### PR TITLE
feat(deploy): add predeploy script

### DIFF
--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -6,6 +6,24 @@ Steps to deploy the full system to production.
 
 - Firebase CLI authenticated: `firebase login`
 - Correct project selected: `firebase use oww-maco`
+- `gcloud` authenticated against the same project (needed for gateway secrets)
+- Operations repo cloned as a sibling of `machine-auth/`
+
+## 0. Predeploy (automation)
+
+Build every deployable artifact in one shot:
+
+```bash
+npm run predeploy
+```
+
+Runs: `firebase use` check → `generate-env` → install+build for `functions/`,
+`web/`, the gateway payload (Bazel + .env from gcloud secrets), and
+`checkout-kiosk/` (electron-rebuild). After this completes, the deploy
+steps below are mechanical — the build outputs they need already exist.
+
+This does NOT rotate secrets, re-save admin docs to refresh custom
+claims, or run smoke tests. Those manual steps still apply.
 
 ## 1. Secrets
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:precommit": "cd web && npm run build && npm test && cd .. && npm run test:web:integration && cd functions && npm test",
     "snapshots:normalize": "node scripts/normalize-snapshots.mjs",
     "block": "npx tsx scripts/port-block.ts --",
+    "predeploy": "scripts/predeploy.sh",
     "deploy:gateway": "npx tsx scripts/deploy-gateway.ts",
     "prepare": "husky"
   },

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright Offene Werkstatt Wädenswil
+# SPDX-License-Identifier: MIT
+#
+# Prepare every deployable artifact for production deploy:
+#   - functions/     install + TypeScript build
+#   - web/           install + Vite build (checkout + admin)
+#   - gateway        Bazel proto build, payload tarball, .env from gcloud secrets
+#   - checkout-kiosk install + electron-rebuild (native NFC bindings)
+#
+# After this completes, the following commands will succeed without any
+# additional preparation:
+#   firebase deploy                                       # functions, rules, hosting
+#   npx tsx scripts/deploy-gateway.ts --host <pi>         # gateway → Raspberry Pi
+#   (kiosk: rsync checkout-kiosk/ to kiosk box, npm install, npm start)
+#
+# This script does NOT cover one-time manual steps from the deploy
+# checklist (secret rotation, custom-claim re-saves, smoke tests).
+# See docs/deployment-checklist.md.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+step() { echo -e "\n${GREEN}[predeploy]${NC} $1"; }
+warn() { echo -e "${YELLOW}[predeploy]${NC} $1"; }
+fail() { echo -e "${RED}[predeploy]${NC} $1"; exit 1; }
+
+command -v node >/dev/null      || fail "node not found"
+command -v firebase >/dev/null  || fail "firebase CLI not found (npm i -g firebase-tools)"
+command -v bazelisk >/dev/null  || fail "bazelisk not found (needed for gateway proto build)"
+command -v gcloud >/dev/null    || fail "gcloud not found (needed to fetch gateway secrets)"
+
+step "Firebase project"
+firebase use
+
+step "Generating env files from operations config"
+npm run generate-env
+
+step "Functions: install + build"
+(cd functions && npm install && npm run build)
+
+step "Web: install + build (checkout + admin)"
+(cd web && npm install && npm run build)
+
+step "Gateway: build payload + generate .env from gcloud secrets"
+npx tsx scripts/deploy-gateway.ts --build-only
+
+step "Checkout kiosk: install + electron-rebuild"
+(cd checkout-kiosk && npm install)
+
+cat <<EOF
+
+${GREEN}[predeploy] OK — all artifacts built.${NC}
+
+Ready to deploy:
+  firebase deploy                                          # functions + rules + hosting
+  npx tsx scripts/deploy-gateway.ts --host <user@host>     # gateway → Pi
+  (kiosk: push checkout-kiosk/ to kiosk machine, run npm install + npm start there)
+
+Manual steps not handled here (see docs/deployment-checklist.md):
+  - Firebase Functions secrets rotation
+  - Custom claims for newly-promoted admins (re-save user doc)
+  - Smoke tests against production
+EOF


### PR DESCRIPTION
One-shot install + build for functions, web, gateway payload, and checkout-kiosk so a subsequent `firebase deploy` / deploy-gateway / kiosk push works without extra prep.