### PR TITLE
fix(firmware): widen FirebaseId to 32 chars for Auth UIDs

### DIFF
--- a/maco_firmware/CLAUDE.md
+++ b/maco_firmware/CLAUDE.md
@@ -640,7 +640,7 @@ Options files provide field-level configuration without modifying `.proto` files
 // Format: fully.qualified.field.name option:value [option:value ...]
 
 maco.proto.TagUid.value max_size:7 fixed_size:true
-maco.proto.FirebaseId.value max_size:20
+maco.proto.FirebaseId.value max_size:32
 maco.proto.KeyBytes.value max_size:16 fixed_size:true
 ```
 
@@ -660,7 +660,7 @@ Define semantic wrapper types in proto for type safety:
 ```protobuf
 // proto/common.proto
 message TagUid { bytes value = 1; }      // 7-byte NFC UID
-message FirebaseId { string value = 1; } // 20-char document ID
+message FirebaseId { string value = 1; } // up to 32-char document ID
 message KeyBytes { bytes value = 1; }    // 16-byte AES key
 ```
 

--- a/maco_firmware/types.h
+++ b/maco_firmware/types.h
@@ -54,12 +54,14 @@ class TagUid {
   std::array<std::byte, kSize> value_;
 };
 
-/// 20-character Firebase document ID.
+/// Firebase document ID. Sized to cover Firebase Auth UIDs (28 chars) used
+/// as `users/{userId}` doc IDs and 20-char Firestore auto-IDs, rounded up to
+/// 32 for headroom.
 class FirebaseId {
  public:
-  static constexpr size_t kMaxSize = 20;
+  static constexpr size_t kMaxSize = 32;
 
-  /// Create from a string view (must be <= 20 characters).
+  /// Create from a string view (must be <= 32 characters).
   static pw::Result<FirebaseId> FromString(std::string_view str) {
     if (str.size() > kMaxSize) {
       return pw::Status::InvalidArgument();

--- a/proto/common.options
+++ b/proto/common.options
@@ -3,8 +3,10 @@
 # 7-byte NFC tag UID - fixed length generates fixed array
 maco.proto.TagUid.value             max_size:7 fixed_length:true
 
-# Firebase document ID (up to 20 alphanumeric characters + null terminator)
-maco.proto.FirebaseId.value         max_size:21
+# Firebase document ID. Sized to cover Firebase Auth UIDs (28 chars) used as
+# `users/{userId}` doc IDs and the older 20-char Firestore auto-IDs, rounded
+# up to a power-of-2-ish 32 for headroom.
+maco.proto.FirebaseId.value         max_size:33
 
 # 16-byte AES-128 key - fixed length generates fixed array
 maco.proto.KeyBytes.value           max_size:16 fixed_length:true


### PR DESCRIPTION
## Summary
- Bug: terminal showed authorized users as **unauthorized** while the api logged a successful checkin. Root cause: nanopb's `FirebaseId.value` field was sized for 20-char Firestore auto-IDs (`max_size:21`), but `users/{userId}` doc IDs are 28-char Firebase Auth UIDs. Decoding `TerminalCheckinResponse` overflowed the buffer → `pb_decode` failed → `DecodeCheckinResponse` returned `DataLoss` → `TagVerifier::AuthorizeTag` called `NotifyUnauthorized()`.
- Bumped to **32** chars (round number, leaves headroom):
  - `proto/common.options` → `max_size:33` (incl. null terminator)
  - `maco_firmware/types.h` → `FirebaseId::kMaxSize = 32`
  - `maco_firmware/CLAUDE.md` → doc strings updated
- Wire-compatible: larger max only relaxes the decode.

## Test plan
- [x] Firmware tested on real hardware — login now succeeds for the previously-rejected user (Auth UID `cGfr4eHhOFOLmwdbGInyhlCYEHf1`)
- [x] `./pw build host` (compile check)
- [x] `npm run test:precommit` (web + functions suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)