### PR TITLE
fix(e2e): wire storage emulator so bill PDFs don't leak to prod

### DIFF
--- a/firebase.e2e.json
+++ b/firebase.e2e.json
@@ -3,6 +3,9 @@
     "rules": "firestore/firestore.rules",
     "indexes": "firestore/firestore.indexes.json"
   },
+  "storage": {
+    "rules": "storage/storage.rules"
+  },
   "functions": [
     {
       "source": "functions",
@@ -29,6 +32,9 @@
     },
     "firestore": {
       "port": 8180
+    },
+    "storage": {
+      "port": 9299
     },
     "ui": {
       "enabled": false

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sync-config": "npx tsx scripts/sync-device-config.ts",
     "test:web": "cd web && npm test",
     "test:web:integration": "npx tsx scripts/port-block.ts -- bash -c 'scripts/emulator-exec.sh --config \"$FIREBASE_E2E_CONFIG\" --only firestore \"cd web && npm run test:integration\"'",
-    "test:web:e2e": "npx tsx scripts/port-block.ts -- bash -c 'scripts/emulator-exec.sh --config \"$FIREBASE_E2E_CONFIG\" --only firestore,auth,functions \"cd web && npm run test:e2e\"'",
+    "test:web:e2e": "npx tsx scripts/port-block.ts -- bash -c 'scripts/emulator-exec.sh --config \"$FIREBASE_E2E_CONFIG\" --only firestore,auth,functions,storage \"cd web && npm run test:e2e\"'",
     "test:all": "npm run test:web && cd functions && npm test",
     "test:precommit": "cd web && npm run build && npm test && cd .. && npm run test:web:integration && cd functions && npm test",
     "snapshots:normalize": "node scripts/normalize-snapshots.mjs",

--- a/scripts/port-block.ts
+++ b/scripts/port-block.ts
@@ -246,16 +246,20 @@ async function main(): Promise<never> {
     EMULATOR_AUTH_PORT: String(9199 + block.offset),
     EMULATOR_FIRESTORE_PORT: String(8180 + block.offset),
     EMULATOR_FUNCTIONS_PORT: String(5101 + block.offset),
+    EMULATOR_STORAGE_PORT: String(9299 + block.offset),
     // Vite reads VITE_EMULATOR_*_PORT for connectXEmulator()
     VITE_EMULATOR_AUTH_PORT: String(9199 + block.offset),
     VITE_EMULATOR_FIRESTORE_PORT: String(8180 + block.offset),
     VITE_EMULATOR_FUNCTIONS_PORT: String(5101 + block.offset),
+    VITE_EMULATOR_STORAGE_PORT: String(9299 + block.offset),
   };
 
   console.error(
     `[port-block] Generated ${runtimeConfigName} (firestore=${
       8180 + block.offset
-    }, auth=${9199 + block.offset}, functions=${5101 + block.offset})`
+    }, auth=${9199 + block.offset}, functions=${5101 + block.offset}, storage=${
+      9299 + block.offset
+    })`
   );
   console.error(`[port-block] Running: ${cmd} ${cmdArgs.join(" ")}`);
 


### PR DESCRIPTION
E2E tests had no Storage emulator configured. `onBillCreate` in the Functions emulator called `getStorage().bucket().save()` and the Admin SDK fell back to prod, leaving ~1600 orphan invoice PDFs in gs://oww-maco.firebasestorage.app/invoices/.

Add a storage block to firebase.e2e.json, include it in test:web:e2e's `--only`, and surface the offset port through port-block for parallel runs.