### PR TITLE
seed: fix entryFees ermaessigt + pre-fill billing address

### DIFF
--- a/scripts/seed-data/seed-public/config-pricing.json
+++ b/scripts/seed-data/seed-public/config-pricing.json
@@ -1,8 +1,8 @@
 {
   "entryFees": {
-    "erwachsen": { "regular": 5, "materialbezug": 0, "intern": 0, "hangenmoos": 0 },
-    "kind":      { "regular": 2.5, "materialbezug": 0, "intern": 0, "hangenmoos": 0 },
-    "firma":     { "regular": 5, "materialbezug": 0, "intern": 0, "hangenmoos": 0 }
+    "erwachsen": { "regular": 5, "ermaessigt": 2.5, "materialbezug": 0, "intern": 0, "hangenmoos": 0 },
+    "kind":      { "regular": 2.5, "ermaessigt": 1.25, "materialbezug": 0, "intern": 0, "hangenmoos": 0 },
+    "firma":     { "regular": 5, "ermaessigt": 2.5, "materialbezug": 0, "intern": 0, "hangenmoos": 0 }
   },
   "slaLayerPrice": { "none": 0.00109, "member": 0.00109, "intern": 0 },
   "workshops": {

--- a/scripts/seed-data/seed-public/users.json
+++ b/scripts/seed-data/seed-public/users.json
@@ -14,7 +14,12 @@
     "roles": ["admin"],
     "termsAcceptedAt": "$now",
     "userType": "erwachsen",
-    "billingAddress": null
+    "billingAddress": {
+      "city": "Wädenswil",
+      "company": "",
+      "street": "Teststrasse 1",
+      "zip": "8820"
+    }
   },
   "NVO6YBzzuBi4K0EuuQ63HHsi7kTa": {
     "created": "$now",
@@ -29,7 +34,12 @@
     "roles": ["admin", "vereinsmitglied"],
     "termsAcceptedAt": "$now",
     "userType": "erwachsen",
-    "billingAddress": null
+    "billingAddress": {
+      "city": "Wädenswil",
+      "company": "",
+      "street": "Teststrasse 1",
+      "zip": "8820"
+    }
   },
   "cM2a3Sosx4LEdTEZFbWOqPKXGF9U": {
     "created": "$now",
@@ -40,7 +50,12 @@
     "roles": ["admin"],
     "termsAcceptedAt": "$now",
     "userType": "erwachsen",
-    "billingAddress": null
+    "billingAddress": {
+      "city": "Wädenswil",
+      "company": "",
+      "street": "Teststrasse 1",
+      "zip": "8820"
+    }
   },
   "mzEFn75h8hRi3U5tx1uHFdqIQxYf": {
     "created": "$now",
@@ -51,7 +66,12 @@
     "roles": [],
     "termsAcceptedAt": "$now",
     "userType": "erwachsen",
-    "billingAddress": null
+    "billingAddress": {
+      "city": "Wädenswil",
+      "company": "",
+      "street": "Teststrasse 1",
+      "zip": "8820"
+    }
   },
   "ziDW8kMcB1aAYd4D5Wd0ZKQqGwRH": {
     "created": "$now",
@@ -62,7 +82,12 @@
     "roles": [],
     "termsAcceptedAt": "$now",
     "userType": "erwachsen",
-    "billingAddress": null
+    "billingAddress": {
+      "city": "Wädenswil",
+      "company": "",
+      "street": "Teststrasse 1",
+      "zip": "8820"
+    }
   },
   "VBfkBQLmdsgHbH4dTCYumVVKPABe": {
     "created": "$now",


### PR DESCRIPTION
- Add validator-required ermaessigt to entryFees.{erwachsen,kind,firma} (dropped during the seed-data split; surfaces as a hard error in the checkout UI per validatePricingConfig in workshop-config.ts).
- Pre-fill a Wädenswil billing address on placeholder users so a fresh dev DB doesn't prompt for it on every login.