### PR TITLE
fix(functions): pack @oww/shared into deploy bundle

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,7 @@
+if grep -q '"@oww/shared": "file:' functions/package.json 2>/dev/null; then
+  echo "ERROR: functions/package.json is in deploy state (@oww/shared points at a tarball)."
+  echo "       Run 'npm run deploy:functions:cleanup' to restore."
+  exit 1
+fi
+
 npm run test:precommit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,12 @@ cd functions/
 npm run build          # Build
 npm run serve          # Local emulator
 npm run test           # All tests
-firebase deploy --only functions
+npm run deploy         # Deploy (wraps firebase deploy + bundles @oww/shared)
 ```
+
+Deploy uses `scripts/deploy-functions.ts` to pack `@oww/shared` and rewrite
+`functions/package.json` to a `file:` ref before invoking
+`firebase deploy --only functions`. See [ADR-0027](docs/adr/0027-shared-typescript-package.md).
 
 **Clean rebuild if stale:**
 ```bash

--- a/docs/adr/0027-shared-typescript-package.md
+++ b/docs/adr/0027-shared-typescript-package.md
@@ -92,13 +92,33 @@ it ever happens.
 
 **Firebase Functions deploy:**
 
-`firebase-tools` resolves npm workspace deps when packing a function
-bundle. If a deploy ever fails with `MODULE_NOT_FOUND` for
-`@oww/shared`, the established fallback is to extend
-`functions[].predeploy` in `firebase.json` with steps that `npm pack`
-`shared/` and `npm install --no-save` the resulting tarball inside
-`functions/` before deploy. This shouldn't be needed under normal
-circumstances and exists only so the failure mode is pre-decided.
+`firebase-tools` does **not** resolve workspace deps when packing a
+function bundle — Cloud Build's `npm install` tries to fetch
+`@oww/shared@*` from the public registry and 404s. `npm install
+--no-save <tarball>` from inside the `functions/` workspace doesn't
+help either: npm walks up to the root `package.json`, sees `functions`
+listed as a workspace member, and re-creates the symlink instead of
+installing from the tarball.
+
+The shipping fix lives in `scripts/prepare-functions-deploy.ts`,
+invoked as a Firebase predeploy hook (`functions[].predeploy` in
+`firebase.json`). It packs `shared/` into
+`functions/oww-shared-X.Y.Z.tgz` and rewrites `functions/package.json`
+so `@oww/shared` points at the tarball via `file:`. Cloud Build then
+installs from the local tarball.
+
+The mutation persists until cleanup. Two paths:
+
+- `npm run deploy:functions` — the wrapper script
+  (`scripts/deploy-functions.ts`) runs `firebase deploy --only functions
+  [args...]` and restores `functions/package.json` + removes the tarball
+  on exit (including on failure or Ctrl+C). Snapshots the pre-deploy
+  bytes so it works regardless of whether `HEAD` is clean.
+- `firebase deploy --only functions` — the predeploy still does the
+  prep, and the deploy still succeeds, but the dirty state stays in the
+  working tree. Run `npm run deploy:functions:cleanup` afterwards. The
+  Husky pre-commit hook refuses commits while the dirty state is in
+  effect, so the modified `package.json` can't leak into git.
 
 ## When to re-evaluate
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -392,7 +392,7 @@ Use this checklist when setting up a new environment:
 ### Firebase Functions
 
 - [ ] All secrets set via `firebase functions:secrets:set`
-- [ ] Functions deployed: `firebase deploy --only functions`
+- [ ] Functions deployed: `npm run deploy:functions`
 
 ### Web App
 

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -65,10 +65,16 @@ Verify `config/pricing` exists in Firestore (Admin → Firestore → `config/pri
 ## 3. Deploy Functions
 
 ```bash
-cd functions
-npm run build
-firebase deploy --only functions
+npm run deploy:functions
 ```
+
+The wrapper packs `@oww/shared` into `functions/` and rewrites
+`functions/package.json` to point at the tarball before invoking
+`firebase deploy --only functions`, then restores both on exit.
+Running `firebase deploy --only functions` directly also works (the
+predeploy hook does the same prep), but leaves the dirty state behind —
+run `npm run deploy:functions:cleanup` afterwards. The Husky pre-commit
+hook refuses commits while the dirty state is in effect.
 
 Verify: Check Functions logs in Firebase Console for startup errors.
 

--- a/firebase.json
+++ b/firebase.json
@@ -20,7 +20,8 @@
       ],
       "predeploy": [
         "npm --prefix \"$RESOURCE_DIR\" run lint",
-        "npm --prefix \"$RESOURCE_DIR\" run build"
+        "npm --prefix \"$RESOURCE_DIR\" run build",
+        "npx tsx scripts/prepare-functions-deploy.ts"
       ]
     }
   ],

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,7 @@
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
-    "deploy": "firebase deploy --only functions",
+    "deploy": "npx tsx ../scripts/deploy-functions.ts",
     "test:unit": "npm run build && mocha --require test/snapshot-normalize-hook.cjs 'lib/src/**/*.test.js' 'lib/test/unit/**/*.test.js'",
     "test:integration": "npm run build && npx tsx ../scripts/port-block.ts -- bash -c 'firebase emulators:exec --project oww-maco --config \"../$FIREBASE_E2E_CONFIG\" --only firestore,auth \"mocha lib/test/integration/**/*.test.js\"'",
     "test": "npm run build && npm run test:unit && npm run test:integration",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "snapshots:normalize": "node scripts/normalize-snapshots.mjs",
     "block": "npx tsx scripts/port-block.ts --",
     "predeploy": "scripts/predeploy.sh",
+    "deploy:functions": "npx tsx scripts/deploy-functions.ts",
+    "deploy:functions:cleanup": "git restore functions/package.json && rm -f functions/oww-shared-*.tgz",
     "deploy:gateway": "npx tsx scripts/deploy-gateway.ts",
     "prepare": "husky",
     "postinstall": "npm run build:shared"

--- a/scripts/deploy-functions.ts
+++ b/scripts/deploy-functions.ts
@@ -1,0 +1,59 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+/**
+ * Deploy Firebase Cloud Functions with auto-cleanup.
+ *
+ * The heavy lifting (packing `@oww/shared` and rewriting
+ * `functions/package.json`) happens in `prepare-functions-deploy.ts`, which
+ * runs as a Firebase predeploy hook. That mutation persists across the
+ * upload step. This wrapper exists to:
+ *
+ *   1. Snapshot `functions/package.json` before deploy so we can restore the
+ *      exact pre-deploy bytes (not whatever happens to be in `HEAD`).
+ *   2. Run `firebase deploy --only functions [args...]`
+ *   3. Restore the snapshot and delete the tarball — even on failure or
+ *      Ctrl+C.
+ *
+ * If you run `firebase deploy --only functions` directly (skipping this
+ * wrapper), the predeploy still does its job, but you'll need to run
+ * `npm run deploy:functions:cleanup` afterwards — and the pre-commit hook
+ * will refuse commits until you do.
+ */
+
+import { spawnSync } from "child_process";
+import { readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const FUNCTIONS = join(ROOT, "functions");
+const PKG_JSON_PATH = join(FUNCTIONS, "package.json");
+
+const originalPkgJson = readFileSync(PKG_JSON_PATH, "utf-8");
+
+function cleanup(): void {
+  writeFileSync(PKG_JSON_PATH, originalPkgJson);
+  for (const entry of readdirSync(FUNCTIONS)) {
+    if (entry.startsWith("oww-shared-") && entry.endsWith(".tgz")) {
+      try {
+        rmSync(join(FUNCTIONS, entry));
+      } catch {
+        // ignore — pre-commit hook will catch leftovers
+      }
+    }
+  }
+}
+
+function cleanupAndExit(signal: NodeJS.Signals): void {
+  cleanup();
+  process.exit(signal === "SIGINT" ? 130 : 143);
+}
+process.on("SIGINT", cleanupAndExit);
+process.on("SIGTERM", cleanupAndExit);
+
+const args = ["deploy", "--only", "functions", ...process.argv.slice(2)];
+const result = spawnSync("firebase", args, { cwd: ROOT, stdio: "inherit" });
+cleanup();
+process.exit(result.status ?? 1);

--- a/scripts/prepare-functions-deploy.ts
+++ b/scripts/prepare-functions-deploy.ts
@@ -1,0 +1,67 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+/**
+ * Bundle `@oww/shared` into `functions/` ahead of Firebase deploy.
+ *
+ * Cloud Build's `npm install` can't resolve the workspace symlink, and
+ * `npm install --no-save` from a workspace member re-creates the symlink
+ * instead of installing the tarball (see ADR-0027). So we:
+ *   1. Pack `shared/` into `functions/oww-shared-X.Y.Z.tgz`
+ *   2. Rewrite `functions/package.json` so `@oww/shared` points at the
+ *      tarball via `file:` — this is what Cloud Build will see and install
+ *
+ * This mutation persists until `npm run deploy:functions:cleanup` runs (or
+ * the wrapper script in `deploy-functions.ts` runs it on exit). The
+ * pre-commit hook refuses to commit while the mutation is in effect.
+ *
+ * Invoked from `firebase.json` `functions[].predeploy`, so it runs whether
+ * deploy is triggered by the wrapper or by `firebase deploy --only functions`
+ * directly.
+ */
+
+import { readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { spawnSync } from "child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const FUNCTIONS = join(ROOT, "functions");
+const SHARED = join(ROOT, "shared");
+const PKG_JSON_PATH = join(FUNCTIONS, "package.json");
+
+for (const entry of readdirSync(FUNCTIONS)) {
+  if (entry.startsWith("oww-shared-") && entry.endsWith(".tgz")) {
+    rmSync(join(FUNCTIONS, entry));
+  }
+}
+
+const packResult = spawnSync(
+  "npm",
+  ["pack", "--pack-destination", FUNCTIONS, SHARED],
+  { cwd: ROOT, stdio: "inherit" },
+);
+if (packResult.status !== 0) {
+  throw new Error(`npm pack failed (exit ${packResult.status})`);
+}
+
+const tarball = readdirSync(FUNCTIONS).find(
+  (f) => f.startsWith("oww-shared-") && f.endsWith(".tgz"),
+);
+if (!tarball) {
+  throw new Error("npm pack did not produce a tarball");
+}
+
+const pkg = JSON.parse(readFileSync(PKG_JSON_PATH, "utf-8")) as {
+  dependencies: Record<string, string>;
+};
+pkg.dependencies["@oww/shared"] = `file:./${tarball}`;
+writeFileSync(PKG_JSON_PATH, JSON.stringify(pkg, null, 2) + "\n");
+
+console.log(
+  `[prepare-functions-deploy] Rewrote functions/package.json @oww/shared -> file:./${tarball}`,
+);
+console.log(
+  `[prepare-functions-deploy] Run 'npm run deploy:functions:cleanup' after deploy to restore.`,
+);


### PR DESCRIPTION
## Summary

- Cloud Build's `npm install` can't resolve the workspace symlink for `@oww/shared` and 404s on the public registry, breaking every Functions deploy since #283 landed.
- ADR-0027's documented fallback (`npm install --no-save <tarball>`) doesn't work — npm walks up to the root `workspaces` field, treats `functions/` as a workspace member, and re-creates the symlink instead of installing from the tarball.
- New flow: `scripts/prepare-functions-deploy.ts` (predeploy hook) packs `shared/` into `functions/oww-shared-X.Y.Z.tgz` and rewrites `functions/package.json` so `@oww/shared` points at the tarball via `file:`. Cloud Build then resolves it locally.
- `scripts/deploy-functions.ts` is a thin wrapper that snapshots `functions/package.json`, runs `firebase deploy --only functions`, and restores it on exit (including SIGINT/SIGTERM). Either `npm run deploy:functions` (auto-cleanup) or raw `firebase deploy --only functions` (manual `npm run deploy:functions:cleanup`) works.
- Husky pre-commit refuses commits while `functions/package.json` is in the dirty `file:` state, so the mutation can't leak into git.
- ADR-0027 and `docs/deployment-checklist.md` updated to reflect what actually shipped.

Verified locally by simulating Cloud Build: copied the modified `functions/` outside the workspace root and `npm install` resolved `@oww/shared` from the tarball cleanly.

## Test plan

- [x] `npm run test:precommit` — green (web unit + integration + functions unit + integration, 390 tests).
- [x] Roundtrip `prepare-functions-deploy.ts` → `deploy:functions:cleanup` restores `functions/package.json` byte-for-byte and removes the tarball.
- [x] Pre-commit hook exits 1 with a clear message when `functions/package.json` is in the deploy state.
- [ ] Real deploy to confirm Cloud Build accepts the bundle (run `npm run deploy:functions` against a test project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)