### PR TITLE
ci: install libpcsclite-dev so npm ci can build the kiosk native dep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,15 @@ jobs:
           distribution: temurin
           java-version: 21
 
+      # The `checkout-kiosk` workspace pulls `nfc-pcsc` → `@pokusew/pcsclite`,
+      # which compiles a native addon that `#include <winscard.h>`. On Linux
+      # that header ships with `libpcsclite-dev`; without it `npm ci` aborts
+      # during gyp build. Kiosk isn't exercised by `test:precommit`, but the
+      # root install resolves every workspace and there's no per-workspace
+      # opt-out for gyp scripts.
+      - name: Install system dependencies (libpcsclite-dev for kiosk native module)
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
+
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
@@ -88,6 +97,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+
+      # Kiosk native dep — see comment in the `test` job above.
+      - name: Install system dependencies (libpcsclite-dev for kiosk native module)
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools


### PR DESCRIPTION
## Summary
- CI presubmit broke after the kiosk refactor (#314) merged: `npm ci` now tries to gyp-build `@pokusew/pcsclite` (pulled in by `nfc-pcsc` from the new `checkout-kiosk` workspace), which `#include <winscard.h>`. The header ships in `libpcsclite-dev` on Linux, and the runner doesn't have it — so the install step exits 1 and takes the whole presubmit + e2e job with it (e.g. [run 26331448994](https://github.com/werkstattwaedi/machine-auth/actions/runs/26331448994)).
- Add an `apt-get install -y libpcsclite-dev` step before `npm ci` in both the `test` and `e2e` jobs. Kiosk isn't exercised by `test:precommit`, but the root install resolves every workspace and there's no per-workspace opt-out for native gyp scripts, so this is the minimal fix.
- Local `npm run test:precommit` is fully green on this branch (web unit 485+3+105 ✓, web integration ✓, functions unit 219 ✓, functions integration 171 ✓).

## Test plan
- [ ] CI `test` job clears the install step and proceeds through `test:precommit`.
- [ ] CI `e2e` job clears the install step and runs Playwright as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)