### PR TITLE
build(kiosk): target Windows x64 NSIS in :prod scripts

### DIFF
--- a/checkout-kiosk/README.md
+++ b/checkout-kiosk/README.md
@@ -86,9 +86,17 @@ threat model.
 ### Production builds (`--prod`)
 
 ```bash
-npm run build:kiosk:prod    # → release/kiosk/oww-kiosk-<ver>-…
-npm run build:admin:prod    # → release/admin/oww-admin-<ver>-…
+npm run build:kiosk:prod    # → release/kiosk/oww-kiosk-<ver>-setup.exe
+npm run build:admin:prod    # → release/admin/oww-admin-<ver>-setup.exe
 ```
+
+The `:prod` scripts always target **Windows x64 NSIS installers**
+(`--win` flag to electron-builder) because both OWW hosts run Windows.
+Cross-compiling from Linux requires Wine
+(`sudo apt install wine64` on WSL2 / Debian); the dev scripts
+(`build:kiosk` / `build:admin` without `:prod`) build for the host
+platform (AppImage on Linux, .dmg on macOS) if you just want to
+smoke-test locally.
 
 The `:prod` scripts pass `--prod` to `inject-build-config.mjs`, which:
 

--- a/checkout-kiosk/package.json
+++ b/checkout-kiosk/package.json
@@ -14,8 +14,8 @@
     "dev:admin": "npm run start:admin",
     "build:kiosk": "cross-env BRIDGE_MODE=kiosk npm run _compile && electron-builder --config electron-builder.kiosk.yml",
     "build:admin": "cross-env BRIDGE_MODE=admin npm run _compile && electron-builder --config electron-builder.admin.yml",
-    "build:kiosk:prod": "cross-env BRIDGE_MODE=kiosk node scripts/inject-build-config.mjs --prod && npm run tsc:main && npm run tsc:renderer && electron-builder --config electron-builder.kiosk.yml",
-    "build:admin:prod": "cross-env BRIDGE_MODE=admin node scripts/inject-build-config.mjs --prod && npm run tsc:main && npm run tsc:renderer && electron-builder --config electron-builder.admin.yml",
+    "build:kiosk:prod": "cross-env BRIDGE_MODE=kiosk node scripts/inject-build-config.mjs --prod && npm run tsc:main && npm run tsc:renderer && electron-builder --config electron-builder.kiosk.yml --win",
+    "build:admin:prod": "cross-env BRIDGE_MODE=admin node scripts/inject-build-config.mjs --prod && npm run tsc:main && npm run tsc:renderer && electron-builder --config electron-builder.admin.yml --win",
     "rebuild": "electron-rebuild",
     "postinstall": "electron-rebuild",
     "typecheck": "cross-env BRIDGE_MODE=kiosk npm run inject-build-config && tsc --noEmit -p tsconfig.json && tsc --noEmit -p src/renderer/tsconfig.json"


### PR DESCRIPTION
## Summary

Both OWW hosts (kiosk + admin workstation) run Windows, so the production build scripts should always produce the Windows installer (`.exe` via NSIS). Without `--win`, electron-builder defaults to the host platform — building from WSL2 / Linux silently produced an AppImage, which isn't useful for shipping to the actual machines.

Follow-up to #341 which baked the build-time config but stopped short of selecting the target OS.

* Adds `--win` to `build:kiosk:prod` + `build:admin:prod`.
* The per-mode `.yml` configs already declared the NSIS x64 target; this just selects it.
* Dev scripts (`build:kiosk` / `build:admin` without `:prod`) unchanged — still host-platform for quick local artifacts.
* README documents the Wine prerequisite for cross-compiling from Linux.

## Test plan
- [x] `npm run build:admin:prod` invokes electron-builder with `--win` (verified by command echo)
- [ ] CI presubmit (this PR)
- [ ] First Windows `.exe` actually rolls off on the build host

🤖 Generated with [Claude Code](https://claude.com/claude-code)