### PR TITLE
fix(seed): repoint laser machines + replace hand-typed catalog IDs (#…

### DIFF
--- a/scripts/seed-data/catalog/glas.json
+++ b/scripts/seed-data/catalog/glas.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "00catmat000000005101",
+    "id": "6qOLCZZ3yGdWoRWWTXXy",
     "code": "5101",
     "name": "Effetre-Glasstäbe klar (50cm)",
     "workshops": [
@@ -23,7 +23,7 @@
     ]
   },
   {
-    "id": "00catmat000000005102",
+    "id": "hyfCOAdMRFIne9nXW5uk",
     "code": "5102",
     "name": "Effetre-Glasstäbe diverse Farben transparent (50cm)",
     "workshops": [
@@ -46,7 +46,7 @@
     ]
   },
   {
-    "id": "00catmat000000005103",
+    "id": "yJHMrbfbiNj18FgQKvVC",
     "code": "5103",
     "name": "Effetre-Glasstäbe diverse Farben opak (50cm)",
     "workshops": [
@@ -69,7 +69,7 @@
     ]
   },
   {
-    "id": "00catmat000000005104",
+    "id": "KUGkcPw3fO66eU69c4Wn",
     "code": "5104",
     "name": "Effetre-Glasstäbe spezielle Farben (50cm)",
     "workshops": [
@@ -92,7 +92,7 @@
     ]
   },
   {
-    "id": "00catmat000000005105",
+    "id": "Ykd0UFkg2XGbS8gJlFhI",
     "code": "5105",
     "name": "Effetre-Glasstäbe (50cm)",
     "workshops": [
@@ -115,7 +115,7 @@
     ]
   },
   {
-    "id": "00catmat000000005106",
+    "id": "AfiTLUqZbPwyiydlamsw",
     "code": "5106",
     "name": "Metal-Stäbe 1.5/2/3mm (10 Stk.)",
     "workshops": [
@@ -138,7 +138,7 @@
     ]
   },
   {
-    "id": "00catmat000000005107",
+    "id": "2TZFCbZ6kU6QpUtpCPvk",
     "code": "5107",
     "name": "Metal-Stab 4mm",
     "workshops": [
@@ -161,7 +161,7 @@
     ]
   },
   {
-    "id": "00catmat000000005108",
+    "id": "Q1pA3zZfFK7FJdPCibHt",
     "code": "5108",
     "name": "Metal-Stab 5mm",
     "workshops": [
@@ -184,7 +184,7 @@
     ]
   },
   {
-    "id": "00catmat000000005109",
+    "id": "HmPevWOP6MG0lBiuu8Rx",
     "code": "5109",
     "name": "Metal-Stab 6mm",
     "workshops": [
@@ -207,7 +207,7 @@
     ]
   },
   {
-    "id": "00catmat000000005110",
+    "id": "xTMCyTln6Tgez4zOOuE3",
     "code": "5110",
     "name": "Putzer (10min)",
     "workshops": [
@@ -230,7 +230,7 @@
     ]
   },
   {
-    "id": "00catmat000000005111",
+    "id": "7z1xGcBRAkV1bDeXMKRA",
     "code": "5111",
     "name": "Perlen-Set (10 Stäbe, Trennmittel, Abdrähtsand)",
     "workshops": [
@@ -253,7 +253,7 @@
     ]
   },
   {
-    "id": "00catmat000000005112",
+    "id": "IttpG0r3FxVEvIc1rbku",
     "code": "5112",
     "name": "Trennmittel Bullseye rot (1 Dose)",
     "workshops": [
@@ -276,7 +276,7 @@
     ]
   },
   {
-    "id": "00catmat000000005113",
+    "id": "CemgYOvETZpvkKi2fMMb",
     "code": "5113",
     "name": "Abdrähtsand (1 Sack)",
     "workshops": [
@@ -299,7 +299,7 @@
     ]
   },
   {
-    "id": "00catmat000000005201",
+    "id": "M0GkArKyh6YynT7nXDL6",
     "code": "5201",
     "name": "Antrazytglas CF/Float 6mm",
     "workshops": [
@@ -322,7 +322,7 @@
     ]
   },
   {
-    "id": "00catmat000000005202",
+    "id": "s8qqKu2GnKsF64RggaZu",
     "code": "5202",
     "name": "Clear-Fuse Glas CF/Float 4mm",
     "workshops": [
@@ -345,7 +345,7 @@
     ]
   },
   {
-    "id": "00catmat000000005203",
+    "id": "dfggAMowuNLmGLV1CRAU",
     "code": "5203",
     "name": "Clear-Base Glas CF/Float 6mm",
     "workshops": [
@@ -368,7 +368,7 @@
     ]
   },
   {
-    "id": "00catmat000000005204",
+    "id": "Cm2WlMBJLzXxNIpRZqEK",
     "code": "5204",
     "name": "Float Glas CF/Float 2mm",
     "workshops": [
@@ -391,7 +391,7 @@
     ]
   },
   {
-    "id": "00catmat000000005205",
+    "id": "gu1Vz0dUhB1V6GUhgj5u",
     "code": "5205",
     "name": "Float Glas CF/Float 8mm",
     "workshops": [
@@ -414,7 +414,7 @@
     ]
   },
   {
-    "id": "00catmat000000005206",
+    "id": "4tSXlCjD7MIOTGyPsbne",
     "code": "5206",
     "name": "Float Glas CF/Float 10mm",
     "workshops": [
@@ -437,7 +437,7 @@
     ]
   },
   {
-    "id": "00catmat000000005207",
+    "id": "N5Xj4wwrDEiypynfPHUR",
     "code": "5207",
     "name": "Bullseye Glas farbig 3mm",
     "workshops": [
@@ -460,7 +460,7 @@
     ]
   },
   {
-    "id": "00catmat000000005208",
+    "id": "pxJnYL3lisy7QibW2eGn",
     "code": "5208",
     "name": "Bullseye Glas klar 2mm",
     "workshops": [
@@ -483,7 +483,7 @@
     ]
   },
   {
-    "id": "00catmat000000005209",
+    "id": "k7Ry3KER8yUuw0F4czSC",
     "code": "5209",
     "name": "Bullseye Glas klar 3mm",
     "workshops": [
@@ -506,7 +506,7 @@
     ]
   },
   {
-    "id": "00catmat000000005210",
+    "id": "hkaZEhfvPzhiA1nTFzaF",
     "code": "5210",
     "name": "Tektos Glas 3mm",
     "workshops": [
@@ -529,7 +529,7 @@
     ]
   },
   {
-    "id": "00catmat000000005211",
+    "id": "KCWtudZWQZU5r2e6GcEn",
     "code": "5211",
     "name": "Uroboros Glas",
     "workshops": [
@@ -552,7 +552,7 @@
     ]
   },
   {
-    "id": "00catmat000000005212",
+    "id": "CtgKkQXkfcEGtRYPdcf9",
     "code": "5212",
     "name": "Brennfolie 1mm",
     "workshops": [
@@ -575,7 +575,7 @@
     ]
   },
   {
-    "id": "00catmat000000005213",
+    "id": "rQW4iqlHZ0DxGlMukbrB",
     "code": "5213",
     "name": "Faserpapier 3/5mm",
     "workshops": [
@@ -598,7 +598,7 @@
     ]
   },
   {
-    "id": "00catmat000000005214",
+    "id": "ke1GawHkBzEZEQB3q2r6",
     "code": "5214",
     "name": "Keramikfaserplatte 10mm",
     "workshops": [
@@ -621,7 +621,7 @@
     ]
   },
   {
-    "id": "00catmat000000005215",
+    "id": "yGs0J9yVyUKh1WTXAVJM",
     "code": "5215",
     "name": "Polsterplatte 20mm",
     "workshops": [
@@ -644,7 +644,7 @@
     ]
   },
   {
-    "id": "00catmat000000005301",
+    "id": "VrjQeVLiHlPX7uY46sa7",
     "code": "5301",
     "name": "Bullseye Stringers Sizzle Black Dichroic 3mm (Dose 50g)",
     "workshops": [
@@ -667,7 +667,7 @@
     ]
   },
   {
-    "id": "00catmat000000005302",
+    "id": "YgBbVPHfOCof4ADiRGBp",
     "code": "5302",
     "name": "Bullseye Stringers Sizzle Black Dichroic 3mm (40cm)",
     "workshops": [
@@ -690,7 +690,7 @@
     ]
   },
   {
-    "id": "00catmat000000005303",
+    "id": "v5rLDG5XeR7C0ivKHHmd",
     "code": "5303",
     "name": "Bullseye Stringers Sizzle Black Dichroic 6mm",
     "workshops": [
@@ -713,7 +713,7 @@
     ]
   },
   {
-    "id": "00catmat000000005304",
+    "id": "eAnl0j2YAGnEulzsQR3y",
     "code": "5304",
     "name": "Bullseye Stringers Sizzle Black Dichroic 3mm (40cm)",
     "workshops": [
@@ -736,7 +736,7 @@
     ]
   },
   {
-    "id": "00catmat000000005305",
+    "id": "GMZLAVABm2nWu2ySGIHW",
     "code": "5305",
     "name": "Bullseye Stringers Sizzle Black Dichroic 6mm",
     "workshops": [
@@ -759,7 +759,7 @@
     ]
   },
   {
-    "id": "00catmat000000005306",
+    "id": "sAAYjhNveM92dFiXAzdd",
     "code": "5306",
     "name": "Confetti (Dose 50g)",
     "workshops": [
@@ -782,7 +782,7 @@
     ]
   },
   {
-    "id": "00catmat000000005307",
+    "id": "VnCgSWbFeBVmcLXw0uE9",
     "code": "5307",
     "name": "Stringers gemischt 2mm (45cm/Stk.)",
     "workshops": [
@@ -805,7 +805,7 @@
     ]
   },
   {
-    "id": "00catmat000000005308",
+    "id": "bj6hdNuu3LIERKZ5tsEd",
     "code": "5308",
     "name": "Stringers gemischt 1mm",
     "workshops": [
@@ -828,7 +828,7 @@
     ]
   },
   {
-    "id": "00catmat000000005309",
+    "id": "gAjmd6cqYaKuVj9e8xoO",
     "code": "5309",
     "name": "Uroboros Dichroic",
     "workshops": [
@@ -851,7 +851,7 @@
     ]
   },
   {
-    "id": "00catmat000000005310",
+    "id": "PKMZma6U0NwAlZvwAXAq",
     "code": "5310",
     "name": "Uroboros Dichroic klein",
     "workshops": [
@@ -874,7 +874,7 @@
     ]
   },
   {
-    "id": "00catmat000000005401",
+    "id": "NANWjNHeXwGykgMlbBAW",
     "code": "5401",
     "name": "Ofen GF 75 (klein)",
     "workshops": [
@@ -897,7 +897,7 @@
     ]
   },
   {
-    "id": "00catmat000000005402",
+    "id": "DAPZCthtuEtqHH27FJrP",
     "code": "5402",
     "name": "Ofen GF 240 (gross)",
     "workshops": [
@@ -920,7 +920,7 @@
     ]
   },
   {
-    "id": "00catmat000000005501",
+    "id": "wy1Bu0f5CqVgzx8f0rj8",
     "code": "5501",
     "name": "Sandstrahlanlage",
     "workshops": [
@@ -943,7 +943,7 @@
     ]
   },
   {
-    "id": "00catmat000000005502",
+    "id": "jP7tuMaKVMZzHARRX7cg",
     "code": "5502",
     "name": "Glasstrahlstation",
     "workshops": [

--- a/scripts/seed-data/catalog/keramik.json
+++ b/scripts/seed-data/catalog/keramik.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "00catmat000000004101",
+    "id": "fAUpZx0KUEWbEzFkuJTf",
     "code": "4101",
     "name": "Raku Rohling Kugel Ø90mm",
     "workshops": [
@@ -22,7 +22,7 @@
     ]
   },
   {
-    "id": "00catmat000000004102",
+    "id": "PCaQYrPr6bcR5tVBKOLm",
     "code": "4102",
     "name": "Raku Rohling Schale Ø90mm",
     "workshops": [
@@ -44,7 +44,7 @@
     ]
   },
   {
-    "id": "00catmat000000004103",
+    "id": "24kGt5zRzEyhjQgO4WKC",
     "code": "4103",
     "name": "Raku Rohling Schale Ø150mm",
     "workshops": [
@@ -66,7 +66,7 @@
     ]
   },
   {
-    "id": "00catmat000000004104",
+    "id": "1zgpD7HOQ0hBNgqRvbET",
     "code": "4104",
     "name": "Raku Rohling Schale flach Ø200mm",
     "workshops": [
@@ -88,7 +88,7 @@
     ]
   },
   {
-    "id": "00catmat000000004105",
+    "id": "90WAE1XHbBHvyobbTrEz",
     "code": "4105",
     "name": "Raku Rohling Schale Viereck Ø200mm",
     "workshops": [
@@ -110,7 +110,7 @@
     ]
   },
   {
-    "id": "00catmat000000004106",
+    "id": "Iks1DPs2uc7ti6pR3qtT",
     "code": "4106",
     "name": "Raku Rohling Struktur Schale Ø90mm",
     "workshops": [
@@ -132,7 +132,7 @@
     ]
   },
   {
-    "id": "00catmat000000004107",
+    "id": "ANSmVXaiUxkLufmIYcyj",
     "code": "4107",
     "name": "Raku Rohling Struktur Schale gross",
     "workshops": [
@@ -154,7 +154,7 @@
     ]
   },
   {
-    "id": "00catmat000000004108",
+    "id": "cyuOveg6VwRAbNYUFyhD",
     "code": "4108",
     "name": "Raku Rohling Struktur gross",
     "workshops": [
@@ -176,7 +176,7 @@
     ]
   },
   {
-    "id": "00catmat000000004201",
+    "id": "hJ8bc1EvPqeKO1ffWg6b",
     "code": "4201",
     "name": "G-Ton, unschamottiert, rot",
     "workshops": [
@@ -199,7 +199,7 @@
     ]
   },
   {
-    "id": "00catmat000000004202",
+    "id": "34FA9KoRWgM1EvLeB1BZ",
     "code": "4202",
     "name": "K144 Manganton, unschamottiert, dunkelbraun",
     "workshops": [
@@ -222,7 +222,7 @@
     ]
   },
   {
-    "id": "00catmat000000004203",
+    "id": "DYqCTKziuNGO9G8cX04e",
     "code": "4203",
     "name": "K127 Manganton, feinschamottiert, dunkelbraun",
     "workshops": [
@@ -245,7 +245,7 @@
     ]
   },
   {
-    "id": "00catmat000000004204",
+    "id": "xBsuF2k51DAZbRQzowVc",
     "code": "4204",
     "name": "B128, fein, cremeweiss",
     "workshops": [
@@ -268,7 +268,7 @@
     ]
   },
   {
-    "id": "00catmat000000004205",
+    "id": "fKWri8ajFgsHjcm9TXi3",
     "code": "4205",
     "name": "B128 CH, feinschamottiert, cremeweiss, Raku",
     "workshops": [
@@ -291,7 +291,7 @@
     ]
   },
   {
-    "id": "00catmat000000004206",
+    "id": "QmFJuF3TFSzpLWSgXFNC",
     "code": "4206",
     "name": "B128 CHF, feinschamottiert, cremeweiss, Raku",
     "workshops": [
@@ -314,7 +314,7 @@
     ]
   },
   {
-    "id": "00catmat000000004207",
+    "id": "R3UcCKT8yJQtWh7GzqC3",
     "code": "4207",
     "name": "B128 CH, grobschamottiert, cremeweiss, Raku",
     "workshops": [
@@ -337,7 +337,7 @@
     ]
   },
   {
-    "id": "00catmat000000004208",
+    "id": "wzsC6DMg6PniOfjQrkGF",
     "code": "4208",
     "name": "GECH 30 F, schamottiert, beige, stabil",
     "workshops": [
@@ -360,7 +360,7 @@
     ]
   },
   {
-    "id": "00catmat000000004209",
+    "id": "1Znfqe3x8mcC9lBY1Tly",
     "code": "4209",
     "name": "GECH 30, grobschamottiert, beige, stabil",
     "workshops": [
@@ -383,7 +383,7 @@
     ]
   },
   {
-    "id": "00catmat000000004210",
+    "id": "evX8YEI81GFwUm3FGgxO",
     "code": "4210",
     "name": "K110 Pyrit-Ton, feinschamottiert, cremeweiss",
     "workshops": [
@@ -406,7 +406,7 @@
     ]
   },
   {
-    "id": "00catmat000000004211",
+    "id": "4ehIMLjIS2Pzf1XsHSqi",
     "code": "4211",
     "name": "GRX 10, feinschamottiert 0–0.3mm, schwarz",
     "workshops": [
@@ -429,7 +429,7 @@
     ]
   },
   {
-    "id": "00catmat000000004212",
+    "id": "rS3RZr1lJjAbGuIOY9RX",
     "code": "4212",
     "name": "GRX 20, grobschamottiert 0–3mm, schwarz",
     "workshops": [
@@ -452,7 +452,7 @@
     ]
   },
   {
-    "id": "00catmat000000004213",
+    "id": "2dB2lhuMKvuUioaWZDG2",
     "code": "4213",
     "name": "Brasil, feinschamottiert, dunkelrot/rotbraun",
     "workshops": [
@@ -475,7 +475,7 @@
     ]
   },
   {
-    "id": "00catmat000000004214",
+    "id": "8yL3Od3Hopc04BFRc37W",
     "code": "4214",
     "name": "Porzellan TM15, Giessporzellan flüssig C42",
     "workshops": [
@@ -498,7 +498,7 @@
     ]
   },
   {
-    "id": "00catmat000000004215",
+    "id": "AuifHNXUmq2dAtMpY1s4",
     "code": "4215",
     "name": "Porzellan, hochgebrannt transluszent",
     "workshops": [

--- a/scripts/seed-data/catalog/machines.json
+++ b/scripts/seed-data/catalog/machines.json
@@ -248,7 +248,7 @@
     ]
   },
   {
-    "id": "00catalog0laser0012",
+    "id": "iVppnklahLU3JuA5BMmH",
     "code": "1012",
     "name": "Laser Cutter",
     "workshops": [

--- a/scripts/seed-data/catalog/makerspace.json
+++ b/scripts/seed-data/catalog/makerspace.json
@@ -138,7 +138,7 @@
     ]
   },
   {
-    "id": "00catmat000000006011",
+    "id": "dkTJHLz7cGYehTuxudQ1",
     "code": "6011",
     "name": "MDF roh 3mm",
     "workshops": [
@@ -187,7 +187,7 @@
     ]
   },
   {
-    "id": "00catmat000000006012",
+    "id": "tjKOJ9nTQM7nyz4cCOJ1",
     "code": "6012",
     "name": "MDF roh 4mm",
     "workshops": [
@@ -236,7 +236,7 @@
     ]
   },
   {
-    "id": "00catmat000000006013",
+    "id": "ohthHKkBU0VIOZoca10f",
     "code": "6013",
     "name": "MDF roh 5mm",
     "workshops": [
@@ -285,7 +285,7 @@
     ]
   },
   {
-    "id": "00catmat000000006014",
+    "id": "41CaxSLfsFYyNpRMEcY9",
     "code": "6014",
     "name": "MDF roh 6mm",
     "workshops": [
@@ -334,7 +334,7 @@
     ]
   },
   {
-    "id": "00catmat000000006003",
+    "id": "M8hIAeBCViNonwpofQ26",
     "code": "6003",
     "name": "Sperrholz Birke 3mm",
     "workshops": [
@@ -367,7 +367,7 @@
     ]
   },
   {
-    "id": "00catmat000000006001",
+    "id": "5yJonLZk77VGfVlTAIQW",
     "code": "6001",
     "name": "Sperrholz Linde 2mm",
     "workshops": [
@@ -400,7 +400,7 @@
     ]
   },
   {
-    "id": "00catmat000000006002",
+    "id": "tyuV4s2SJfHGICIfQtk6",
     "code": "6002",
     "name": "Sperrholz Linde 3mm",
     "workshops": [
@@ -433,7 +433,7 @@
     ]
   },
   {
-    "id": "00catmat000000006010",
+    "id": "rmxo5yp5pYKeSVJFQ47r",
     "code": "6010",
     "name": "Sperrholz Pappel 12mm",
     "workshops": [
@@ -482,7 +482,7 @@
     ]
   },
   {
-    "id": "00catmat000000006005",
+    "id": "qytIF6cJwTT20kEmXDrh",
     "code": "6005",
     "name": "Sperrholz Pappel 3mm",
     "workshops": [
@@ -531,7 +531,7 @@
     ]
   },
   {
-    "id": "00catmat000000006006",
+    "id": "sjqBPGsCWRUqTJeMwt0H",
     "code": "6006",
     "name": "Sperrholz Pappel 4mm",
     "workshops": [
@@ -580,7 +580,7 @@
     ]
   },
   {
-    "id": "00catmat000000006007",
+    "id": "6jrq1wr1aji9BaCjOsdu",
     "code": "6007",
     "name": "Sperrholz Pappel 5mm",
     "workshops": [
@@ -629,7 +629,7 @@
     ]
   },
   {
-    "id": "00catmat000000006008",
+    "id": "5bdGjl2ftNLCGkusPFPG",
     "code": "6008",
     "name": "Sperrholz Pappel 6mm",
     "workshops": [
@@ -678,7 +678,7 @@
     ]
   },
   {
-    "id": "00catmat000000006009",
+    "id": "XaiS8TV3XUJfkt1dMFGo",
     "code": "6009",
     "name": "Sperrholz Pappel 8mm",
     "workshops": [
@@ -727,7 +727,7 @@
     ]
   },
   {
-    "id": "00catmat000000006016",
+    "id": "56nJuPdSpBUmDZ72aVGE",
     "code": "6016",
     "name": "Sperrholz Seekiefer 12mm",
     "workshops": [
@@ -776,7 +776,7 @@
     ]
   },
   {
-    "id": "00catmat000000006015",
+    "id": "8CLQLHMMFHy4oujuBkbk",
     "code": "6015",
     "name": "Sperrholz Seekiefer 7mm",
     "workshops": [
@@ -825,7 +825,7 @@
     ]
   },
   {
-    "id": "00catmat000000006004",
+    "id": "qCGDbzCFL1WLIMOiZFJd",
     "code": "6004",
     "name": "Sperrholz Wallnuss 3mm",
     "workshops": [

--- a/scripts/seed-data/seed-public/machines.json
+++ b/scripts/seed-data/seed-public/machines.json
@@ -2,7 +2,7 @@
   "ZWVLzWQi40rRvM30MGnb": {
     "name": "Laser Cutter",
     "workshop": "makerspace",
-    "checkoutTemplateId": "$ref:catalog/37n2KSXmmgFbN7JJdQ2s",
+    "checkoutTemplateId": "$ref:catalog/iVppnklahLU3JuA5BMmH",
     "requiredPermission": ["$ref:permission/39ozgRe5iMWF5LccFNir"],
     "maco": "$ref:maco/aaa5427ee1cca38aeea743ae",
     "control": {}
@@ -10,7 +10,7 @@
   "kMeIRDWEaDUzIbzGCZzP": {
     "name": "Lampe",
     "workshop": "makerspace",
-    "checkoutTemplateId": "$ref:catalog/37n2KSXmmgFbN7JJdQ2s",
+    "checkoutTemplateId": "$ref:catalog/iVppnklahLU3JuA5BMmH",
     "requiredPermission": ["$ref:permission/39ozgRe5iMWF5LccFNir"],
     "maco": "$ref:maco/513803d6d96a166da166f635",
     "control": {}

--- a/scripts/seed-emulator.ts
+++ b/scripts/seed-emulator.ts
@@ -11,9 +11,11 @@
  *   - Otherwise, fall back to scripts/seed-data/seed-public/ —
  *     placeholder values safe to check into the public repo.
  *
- * Catalog (~150 items) always loads from scripts/seed-data/catalog/*.json
- * regardless of fixture set; the catalog is public-safe and shared
- * between both repos.
+ * Catalog (~150 items) loads from the SAME fixture set as everything else:
+ * the ops repo's catalog when ops fixtures are present, otherwise the public
+ * example catalog under scripts/seed-data/catalog/*.json. The two catalogs
+ * are independent — prod (ops) is the source of truth; the public set is
+ * example/test data and may diverge.
  *
  * Modes:
  *   --mode=full        (default) seeds everything including auth users.
@@ -38,7 +40,6 @@ import { getFirestore, Timestamp } from "firebase-admin/firestore";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
 const publicSeedDir = join(__dirname, "seed-data", "seed-public");
-const catalogDir = join(__dirname, "seed-data", "catalog");
 
 const opsDir =
   process.env.OPERATIONS_CONFIG_DIR ||
@@ -48,6 +49,13 @@ const fixturesDir = existsSync(join(opsSeedDir, "permissions.json"))
   ? opsSeedDir
   : publicSeedDir;
 const usingOpsFixtures = fixturesDir === opsSeedDir;
+
+// Catalog follows the active fixture set so each dataset is self-consistent:
+// the ops catalog (prod source of truth) when ops fixtures are present, else
+// the public example catalog. The two are independent and may diverge.
+const catalogDir = usingOpsFixtures
+  ? join(opsSeedDir, "catalog")
+  : join(__dirname, "seed-data", "catalog");
 
 process.env.FIRESTORE_EMULATOR_HOST ??= "127.0.0.1:8080";
 process.env.FIREBASE_AUTH_EMULATOR_HOST ??= "127.0.0.1:9099";
@@ -85,6 +93,71 @@ function resolveValue(value: unknown): unknown {
 
 function loadFixture<T>(filename: string): T {
   return JSON.parse(readFileSync(join(fixturesDir, filename), "utf-8")) as T;
+}
+
+// Collect every "$ref:collection/docId" string in a fixture value tree.
+function collectRefs(value: unknown, out: string[]): void {
+  if (typeof value === "string" && value.startsWith("$ref:")) out.push(value.slice(5));
+  else if (Array.isArray(value)) for (const v of value) collectRefs(v, out);
+  else if (value !== null && typeof value === "object")
+    for (const v of Object.values(value as Record<string, unknown>)) collectRefs(v, out);
+}
+
+/**
+ * Fail fast if any `$ref` points at a doc this run won't create. The resolver
+ * (`resolveValue`) turns a `$ref` into a live `DocumentReference` without
+ * checking existence, so a typo'd or stale ref silently seeds a pointer to a
+ * phantom doc — exactly the dangling catalog ref behind issue #377. Validating
+ * only refs into collections this run seeds (others can't be checked here).
+ */
+function assertNoDanglingRefs(mode: "full" | "structural"): void {
+  const ids: Record<string, Set<string>> = {};
+  const add = (coll: string, id: string) => (ids[coll] ??= new Set<string>()).add(id);
+  const sources: Array<{ src: string; data: unknown }> = [];
+
+  for (const file of readdirSync(catalogDir).filter((f) => f.endsWith(".json")).sort()) {
+    const arr = JSON.parse(readFileSync(join(catalogDir, file), "utf-8")) as Array<{ id: string }>;
+    for (const item of arr) add("catalog", item.id);
+    sources.push({ src: `catalog/${file}`, data: arr });
+  }
+
+  const keyed: Array<[string, string]> = [
+    ["permission", "permissions.json"],
+    ["maco", "maco.json"],
+    ["machine", "machines.json"],
+    ["price_lists", "price-lists.json"],
+  ];
+  if (mode === "full") keyed.push(["users", "users.json"], ["tokens", "tokens.json"]);
+  for (const [coll, file] of keyed) {
+    const data = loadFixture<Record<string, unknown>>(file);
+    for (const id of Object.keys(data)) add(coll, id);
+    sources.push({ src: file, data });
+  }
+
+  for (const file of ["config-pricing.json", "config-catalog-references.json"]) {
+    sources.push({ src: file, data: loadFixture(file) });
+  }
+  for (const id of ["pricing", "catalog-references", "billing"]) add("config", id);
+
+  const dangling: string[] = [];
+  for (const { src, data } of sources) {
+    const refs: string[] = [];
+    collectRefs(data, refs);
+    for (const ref of refs) {
+      const slash = ref.indexOf("/");
+      const coll = ref.slice(0, slash);
+      const id = ref.slice(slash + 1);
+      if (ids[coll] && !ids[coll].has(id)) dangling.push(`${src}: $ref:${ref}`);
+    }
+  }
+
+  if (dangling.length > 0) {
+    throw new Error(
+      `Seed aborted: ${dangling.length} dangling $ref(s) point at docs not in the seed set:\n  ` +
+        dangling.join("\n  ") +
+        "\nFix the fixture, or the referenced doc id, before seeding.",
+    );
+  }
 }
 
 async function seedCollection(
@@ -175,6 +248,8 @@ async function seed() {
   console.log(
     `Seeding emulator (mode=${mode}, fixtures=${usingOpsFixtures ? "operations repo" : "public placeholders"})...`,
   );
+
+  assertNoDanglingRefs(mode);
 
   // Structural — always written.
   await seedCollection("permission", loadFixture("permissions.json"));


### PR DESCRIPTION
…377)

Laser Cutter + Lampe machines referenced a catalog doc that never existed (dangling $ref), so usage uploads failed accumulation with "Catalog entry not found". Regenerate the 82 hand-typed 00catmat/ 00catalog IDs as real Firestore IDs, repoint the example laser machines, and add a dangling-$ref guard so a phantom reference can't ship silently again. Catalog now follows the active fixture set.