### PR TITLE
predeploy: self-heal leftover functions deploy state

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "block": "npx tsx scripts/port-block.ts --",
     "predeploy": "scripts/predeploy.sh",
     "deploy:functions": "npx tsx scripts/deploy-functions.ts",
-    "deploy:functions:cleanup": "git restore functions/package.json && rm -f functions/oww-shared-*.tgz",
+    "deploy:functions:cleanup": "git restore functions/package.json && rm -f functions/oww-shared-*.tgz && rm -rf functions/node_modules/@oww/shared",
     "deploy:gateway": "npx tsx scripts/deploy-gateway.ts",
     "prepare": "husky",
     "postinstall": "npm run build:shared"

--- a/scripts/deploy-functions.ts
+++ b/scripts/deploy-functions.ts
@@ -44,6 +44,19 @@ function cleanup(): void {
       }
     }
   }
+  // The `file:` install extracts a real `functions/node_modules/@oww/shared`
+  // that shadows the hoisted workspace symlink. Restoring package.json isn't
+  // enough — a later build/install resolves this stale copy and fails on
+  // exports added since (the deploy-state bug). Remove it so the workspace
+  // symlink takes over again.
+  try {
+    rmSync(join(FUNCTIONS, "node_modules", "@oww", "shared"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore — pre-commit hook + predeploy guard also clear it
+  }
 }
 
 function cleanupAndExit(signal: NodeJS.Signals): void {

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -42,6 +42,19 @@ firebase use
 step "Generating env files from operations config"
 npm run generate-env
 
+# A prior deploy rewrites functions/package.json's @oww/shared to a packed
+# `file:` tarball (see scripts/deploy-functions.ts) and deploy:functions:cleanup
+# normally reverts it. An interrupted/failed deploy can leave that state
+# behind; the next `npm install` then resolves @oww/shared to the *stale*
+# tarball, so `tsc` can't see exports added since (mirrors the husky
+# pre-commit guard). Self-heal here so predeploy never builds against a
+# stale shared package.
+if grep -q '"@oww/shared": "file:' functions/package.json 2>/dev/null; then
+  warn "functions/package.json is in deploy state (@oww/shared → packed tarball, leftover from an interrupted deploy). Restoring the workspace ref."
+  git restore functions/package.json
+  rm -f functions/oww-shared-*.tgz
+fi
+
 step "Install all workspace dependencies (root)"
 npm install
 

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -54,6 +54,11 @@ if grep -q '"@oww/shared": "file:' functions/package.json 2>/dev/null; then
   git restore functions/package.json
   rm -f functions/oww-shared-*.tgz
 fi
+# The `file:` install extracts a real `functions/node_modules/@oww/shared`
+# that shadows the hoisted workspace symlink. `npm install` does NOT prune
+# it, so tsc keeps resolving the stale copy even after the ref is restored —
+# always clear it before installing.
+rm -rf functions/node_modules/@oww/shared
 
 step "Install all workspace dependencies (root)"
 npm install


### PR DESCRIPTION
## Problem
A deploy rewrites `functions/package.json`'s `@oww/shared` to a packed `file:` tarball (`scripts/deploy-functions.ts`); `deploy:functions:cleanup` reverts it. An interrupted/failed deploy leaves that state behind — the next `predeploy` `npm install` then resolves `@oww/shared` to the **stale** tarball, and `tsc` fails on exports added since (e.g. `isMachineItem` from #392):

```
error TS2305: Module '"@oww/shared"' has no exported member 'isMachineItem'.
```

## Fix
`predeploy.sh` now detects the `"@oww/shared": "file:` state before `npm install` and self-heals (`git restore functions/package.json` + `rm -f functions/oww-shared-*.tgz`) — mirroring the existing husky pre-commit guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)