### PR TITLE
deploy: restore package-lock.json in deploy-state cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "block": "npx tsx scripts/port-block.ts --",
     "predeploy": "scripts/predeploy.sh",
     "deploy:functions": "npx tsx scripts/deploy-functions.ts",
-    "deploy:functions:cleanup": "git restore functions/package.json && rm -f functions/oww-shared-*.tgz && rm -rf functions/node_modules/@oww/shared",
+    "deploy:functions:cleanup": "git restore functions/package.json package-lock.json && rm -f functions/oww-shared-*.tgz && rm -rf functions/node_modules/@oww/shared",
     "deploy:gateway": "npx tsx scripts/deploy-gateway.ts",
     "prepare": "husky",
     "postinstall": "npm run build:shared"

--- a/scripts/deploy-functions.ts
+++ b/scripts/deploy-functions.ts
@@ -30,11 +30,19 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const FUNCTIONS = join(ROOT, "functions");
 const PKG_JSON_PATH = join(FUNCTIONS, "package.json");
+const LOCK_PATH = join(ROOT, "package-lock.json");
 
 const originalPkgJson = readFileSync(PKG_JSON_PATH, "utf-8");
+// Snapshot the lockfile too: any `npm install` while package.json points
+// @oww/shared at the `file:` tarball rewrites the lock to pin
+// functions/node_modules/@oww/shared at that tarball. Restoring only
+// package.json leaves that pin, so later installs keep re-extracting the
+// stale copy (the deploy-state bug). Restore both.
+const originalLock = readFileSync(LOCK_PATH, "utf-8");
 
 function cleanup(): void {
   writeFileSync(PKG_JSON_PATH, originalPkgJson);
+  writeFileSync(LOCK_PATH, originalLock);
   for (const entry of readdirSync(FUNCTIONS)) {
     if (entry.startsWith("oww-shared-") && entry.endsWith(".tgz")) {
       try {

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -42,22 +42,21 @@ firebase use
 step "Generating env files from operations config"
 npm run generate-env
 
-# A prior deploy rewrites functions/package.json's @oww/shared to a packed
-# `file:` tarball (see scripts/deploy-functions.ts) and deploy:functions:cleanup
-# normally reverts it. An interrupted/failed deploy can leave that state
-# behind; the next `npm install` then resolves @oww/shared to the *stale*
-# tarball, so `tsc` can't see exports added since (mirrors the husky
-# pre-commit guard). Self-heal here so predeploy never builds against a
-# stale shared package.
-if grep -q '"@oww/shared": "file:' functions/package.json 2>/dev/null; then
-  warn "functions/package.json is in deploy state (@oww/shared → packed tarball, leftover from an interrupted deploy). Restoring the workspace ref."
-  git restore functions/package.json
+# Self-heal leftover functions deploy state. A deploy points @oww/shared at a
+# packed `file:` tarball (scripts/{prepare,deploy}-functions-deploy.ts).
+# An interrupted deploy — or an `npm install` run while in that state —
+# leaves package.json AND/OR package-lock.json pinning the tarball. The lock
+# is the sticky one: even after package.json is restored, npm keeps
+# re-extracting a stale functions/node_modules/@oww/shared (missing exports
+# added since), so tsc fails. Restore BOTH files before install.
+if grep -q '"@oww/shared": "file:' functions/package.json 2>/dev/null \
+  || grep -q 'oww-shared-[0-9].*\.tgz' package-lock.json 2>/dev/null; then
+  warn "Leftover functions deploy state detected (package.json/lockfile pin @oww/shared at a packed tarball). Restoring."
+  git restore functions/package.json package-lock.json
   rm -f functions/oww-shared-*.tgz
 fi
-# The `file:` install extracts a real `functions/node_modules/@oww/shared`
-# that shadows the hoisted workspace symlink. `npm install` does NOT prune
-# it, so tsc keeps resolving the stale copy even after the ref is restored —
-# always clear it before installing.
+# Even when the refs are clean, a prior `file:` install can leave the
+# extracted copy behind, shadowing the workspace symlink. Always clear it.
 rm -rf functions/node_modules/@oww/shared
 
 step "Install all workspace dependencies (root)"


### PR DESCRIPTION
Follow-up to #398. The deploy-state bug had a third stale artifact we hadn't handled: **`package-lock.json`**.

An `npm install` while `functions/package.json` points `@oww/shared` at the packed `file:` tarball rewrites the lock to pin `functions/node_modules/@oww/shared → file:functions/oww-shared-0.0.0.tgz`. Restoring `package.json` (and removing the tarball + extracted dir) wasn't enough — the lock makes every later `npm install` **re-extract the stale tarball from npm's cache**, so `tsc` keeps failing with `Module '"@oww/shared"' has no exported member 'isMachineItem'` even on a clean `package.json`. That's why the #398 guard (gated on `package.json` only) missed it.

Fixes the lock in all three cleanup paths:
- `scripts/deploy-functions.ts` — snapshot + restore `package-lock.json` alongside `package.json`.
- `deploy:functions:cleanup` — `git restore` the lock too.
- `scripts/predeploy.sh` guard — also trigger on a stale lock entry (`oww-shared-*.tgz`), not just a `file:` package.json, and restore both before install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)