### PR TITLE
fix(gateway): use FieldFilter for printJobs queries

### DIFF
--- a/maco_gateway/maco_gateway/print_worker.py
+++ b/maco_gateway/maco_gateway/print_worker.py
@@ -64,6 +64,7 @@ class PrintWorker:
 
         # Deferred import: only printer-equipped gateways need the SDK.
         from google.cloud import firestore  # type: ignore
+        from google.cloud.firestore_v1.base_query import FieldFilter
 
         # The client honours FIRESTORE_EMULATOR_HOST (dev, anonymous creds)
         # and GOOGLE_APPLICATION_CREDENTIALS (prod service account)
@@ -77,7 +78,7 @@ class PrintWorker:
         self._recover_orphaned_jobs()
 
         query = self._db.collection(PRINT_JOBS_COLLECTION).where(
-            "status", "==", "queued"
+            filter=FieldFilter("status", "==", "queued")
         )
         logger.info(
             "Print worker: listening for queued jobs → printer %s:%d",
@@ -102,10 +103,12 @@ class PrintWorker:
         TTL — the admin UI just times out with a misleading "printer
         unreachable". Reset them so the operator gets a clear signal instead.
         """
+        from google.cloud.firestore_v1.base_query import FieldFilter
+
         try:
             stuck = (
                 self._db.collection(PRINT_JOBS_COLLECTION)
-                .where("status", "==", "printing")
+                .where(filter=FieldFilter("status", "==", "printing"))
                 .stream()
             )
             for doc in stuck:


### PR DESCRIPTION
Follow-up to #402.

Replaces the two positional `.where("status", "==", …)` calls in the print worker (the queued-job listener and the startup orphaned-`printing` recovery query) with the `filter=FieldFilter(...)` keyword form.

This silences the deprecation warning observed in the gateway logs on startup after the print-worker deploy:

```
UserWarning: Detected filter using positional arguments. Prefer using the 'filter' keyword argument instead.
```

`FieldFilter` is available in the pinned `google-cloud-firestore>=2.16,<3`. The import stays deferred (inside the methods) so printer-less gateways still never import the Firestore SDK. Behaviour is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)