### PR TITLE
Make admin NFC scan diagnosable + retry through readingerror

### DIFF
--- a/web/apps/admin/src/nfc/use-tag-scan.ts
+++ b/web/apps/admin/src/nfc/use-tag-scan.ts
@@ -53,6 +53,15 @@ export function parseSunUrl(raw: string): { picc: string; cmac: string } {
   return { picc, cmac }
 }
 
+/** Non-throwing variant for scanning multiple records. */
+function tryParseSunUrl(raw: string): { picc: string; cmac: string } | null {
+  try {
+    return parseSunUrl(raw)
+  } catch {
+    return null
+  }
+}
+
 /** Time to wait for a tap before giving up. */
 const SCAN_TIMEOUT_MS = 30_000
 
@@ -89,13 +98,13 @@ export function scanTagUrl(): Promise<{ picc: string; cmac: string }> {
 
     reader.addEventListener("reading", (event) => {
       try {
+        // Record types that can carry a URL. Decoding a binary record
+        // (smart poster, raw MIME, …) as UTF-8 risks a spurious match.
+        const URL_TYPES = ["url", "absolute-url", "text"]
+        const seen: string[] = []
         for (const record of event.message.records) {
-          // Only URL/text records can carry a SUN URL. Decoding a binary
-          // record (smart poster, raw MIME, …) as UTF-8 risks a spurious
-          // "picc=" match on arbitrary bytes.
-          if (record.recordType !== "url" && record.recordType !== "text") {
-            continue
-          }
+          seen.push(record.recordType)
+          if (!URL_TYPES.includes(record.recordType)) continue
           if (!record.data) continue
           // `encoding` is only meaningful for text records; url records are
           // always UTF-8.
@@ -104,19 +113,26 @@ export function scanTagUrl(): Promise<{ picc: string; cmac: string }> {
               ? record.encoding || "utf-8"
               : "utf-8"
           const text = new TextDecoder(encoding).decode(record.data)
-          if (text.includes("picc=") || text.includes("PICC=")) {
-            finish(null, parseSunUrl(text))
+          const sun = tryParseSunUrl(text)
+          if (sun) {
+            finish(null, sun)
             return
           }
         }
-        finish(new Error("Kein OWW-Tag erkannt."))
+        // Include the NDEF record types we actually saw — on a phone with no
+        // dev console this is the only window into why a tap was rejected.
+        finish(
+          new Error(
+            `Kein OWW-Tag erkannt (NDEF: ${seen.join(", ") || "leer"}).`,
+          ),
+        )
       } catch (err) {
         finish(err instanceof Error ? err : new Error(String(err)))
       }
     })
 
     reader.addEventListener("readingerror", () => {
-      finish(new Error("Tag konnte nicht gelesen werden."))
+      finish(new Error("NDEF-Lesefehler – Tag erneut auflegen."))
     })
 
     reader.scan({ signal: controller.signal }).catch((err: unknown) => {

--- a/web/apps/admin/src/nfc/use-tag-scan.ts
+++ b/web/apps/admin/src/nfc/use-tag-scan.ts
@@ -91,8 +91,21 @@ export function scanTagUrl(): Promise<{ picc: string; cmac: string }> {
       else resolve(value!)
     }
 
+    // NTAG424/SDM tags intermittently throw `readingerror` on the first tap.
+    // We keep the scan active instead of settling, so the operator can simply
+    // re-tap; only the timeout gives up. `readErrors` lets the timeout message
+    // distinguish "nothing tapped" from "tapped but every read failed".
+    let readErrors = 0
+
     const timer = setTimeout(
-      () => finish(new Error("Kein Tag erkannt (Zeitüberschreitung).")),
+      () =>
+        finish(
+          new Error(
+            readErrors > 0
+              ? `NDEF-Lesefehler – Tag konnte nicht gelesen werden (${readErrors}× versucht).`
+              : "Kein Tag erkannt (Zeitüberschreitung).",
+          ),
+        ),
       SCAN_TIMEOUT_MS,
     )
 
@@ -132,7 +145,10 @@ export function scanTagUrl(): Promise<{ picc: string; cmac: string }> {
     })
 
     reader.addEventListener("readingerror", () => {
-      finish(new Error("NDEF-Lesefehler – Tag erneut auflegen."))
+      // Do NOT settle — leave the scan armed so the operator can re-tap.
+      readErrors += 1
+      // eslint-disable-next-line no-console
+      console.warn(`Web NFC readingerror #${readErrors} — re-tap to retry`)
     })
 
     reader.scan({ signal: controller.signal }).catch((err: unknown) => {

--- a/web/apps/admin/src/routes/_authenticated/users/$userId.tsx
+++ b/web/apps/admin/src/routes/_authenticated/users/$userId.tsx
@@ -84,9 +84,11 @@ function UserDetailPage() {
   // resolves the real UID server-side (tags use Random-ID). Error toast is
   // owned by the mutation hook (ADR-0025); success-path info toasts below.
   const { supported: nfcSupported, scanTag } = useTagScan()
+  // No static errorMessage: let the hook surface the specific German
+  // message (NFC permission, NDEF read error + record types, or the
+  // backend's "Ungültiger Tag") so failures are diagnosable on-device.
   const scanTagMutation = useAsyncMutation<ResolveTagResult>({
     context: "admin.userScanTag",
-    errorMessage: "Tag konnte nicht gelesen werden",
   })
   const [selectedPermissions, setSelectedPermissions] = useState<string[]>([])
   const [newTagId, setNewTagId] = useState("")

--- a/web/apps/admin/src/routes/_authenticated/users/index.tsx
+++ b/web/apps/admin/src/routes/_authenticated/users/index.tsx
@@ -36,9 +36,10 @@ function UsersPage() {
 
   // Web NFC: scan a tag and jump to its owner (Chrome/Android only).
   const { supported: nfcSupported, scanTag } = useTagScan()
+  // No static errorMessage: surface the specific German failure reason
+  // (NFC permission / NDEF read error + record types / backend error).
   const scanMutation = useAsyncMutation<ResolveTagResult>({
     context: "admin.usersScanTag",
-    errorMessage: "Tag konnte nicht gelesen werden",
   })
 
   const handleScanTag = async () => {


### PR DESCRIPTION
Follow-up to #408 — on-device debugging of the admin Web NFC tag scan.

**Note:** #408 was merged at an earlier commit, so the diagnostic changes that were pushed to its branch afterwards never reached `main` (they were deployed to admin hosting directly). This PR brings those into `main` **plus** the readingerror retry below.

## Symptom
First real on-phone test: every scan showed a generic "Tag konnte nicht gelesen werden". Telemetry (`logClientError`, context `admin.usersScanTag`) showed `code: "unknown"` → the failure was in the on-device NFC read, before `resolveTag` was ever called. With the diagnostics deployed, the toast pinpointed it: **`NDEF-Lesefehler`** — Chrome's `NDEFReader` fires `readingerror` on the NTAG424 DNA/SDM tag, even though the OS-level read (and the TagInfo app) read it fine.

## Changes
- **Diagnosability** (was orphaned from #408): drop the static `errorMessage` that masked every failure; surface the specific German reason; include the observed NDEF record types in the "no tag" error (`Kein OWW-Tag erkannt (NDEF: …)`); accept `absolute-url` records.
- **Retry through `readingerror`**: a `readingerror` no longer aborts the scan. The scan stays armed so the operator can simply re-tap (NTAG424/SDM readingerror is typically intermittent); only the timeout gives up, and it reports how many reads failed (`… (3× versucht)`). Also `console.warn`s each readingerror for `chrome://inspect`.

## Why no test for the retry
The retry is a Web NFC lifecycle behaviour (scan stays armed across `readingerror` events) that the existing fake exercises only at the single-event level. The pure parser + record-type guard remain covered (11 unit tests pass). This needs the on-device confirmation below.

## Verification
- admin typecheck + `use-tag-scan` unit tests (11) pass
- **On-device (pending):** deploy admin hosting, scan, and re-tap a few times if the first read errors — confirm it eventually reads (intermittent) vs. always errors to timeout (deterministic → we pivot to OS-dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)