### PR TITLE
fix(personalize): NDEF length off-by-one made tags unreadable by standard NFC readers

### DIFF
--- a/maco_firmware/apps/personalize/BUILD.bazel
+++ b/maco_firmware/apps/personalize/BUILD.bazel
@@ -10,6 +10,7 @@
 
 load("@particle_bazel//rules:particle_firmware.bzl", "particle_firmware", "particle_flash_binary")
 load("@pigweed//pw_system/py:console.bzl", "device_console")
+load("@pigweed//pw_unit_test:pw_cc_test.bzl", "pw_cc_test")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -38,6 +39,12 @@ cc_library(
         "@pigweed//pw_bytes",
         "@pigweed//pw_result",
     ],
+)
+
+pw_cc_test(
+    name = "sdm_constants_test",
+    srcs = ["sdm_constants_test.cc"],
+    deps = [":sdm_constants"],
 )
 
 # Tag identification - classify tags as factory/MaCo/unknown

--- a/maco_firmware/apps/personalize/sdm_constants.cc
+++ b/maco_firmware/apps/personalize/sdm_constants.cc
@@ -15,8 +15,12 @@ pw::Result<NdefTemplate> BuildNdefTemplate(std::string_view base_url) {
   const size_t url_total = base_url.size() + kUrlSuffixLength;
   // Payload = URI prefix code (1) + url_total
   const size_t payload_length = 1 + url_total;
-  // NDEF message = header(3) + payload_length(1) + type(1) + payload
-  const size_t ndef_message_length = 3 + payload_length;
+  // NDEF SR record = 4-byte header [flags(1) + type-length(1) +
+  // payload-length(1) + type(1)] + payload. (A previous off-by-one used 3
+  // here, so NLEN under-reported by one byte and the record's declared
+  // payload overran the message — every spec-compliant NDEF reader, incl.
+  // Android tap-to-open and Web NFC, then rejected the tag as malformed.)
+  const size_t ndef_message_length = 4 + payload_length;
   // Total file = NLEN(2) + NDEF message
   const size_t total_size = 2 + ndef_message_length;
 

--- a/maco_firmware/apps/personalize/sdm_constants_test.cc
+++ b/maco_firmware/apps/personalize/sdm_constants_test.cc
@@ -1,0 +1,87 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+#include "maco_firmware/apps/personalize/sdm_constants.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "pw_unit_test/framework.h"
+
+namespace maco::personalize::sdm {
+namespace {
+
+constexpr std::string_view kBaseUrl = "id.werkstattwaedi.ch/";
+
+uint8_t Byte(const NdefTemplate& t, size_t i) {
+  return std::to_integer<uint8_t>(t.data[i]);
+}
+
+// Regression: the NDEF short-record header is 4 bytes (flags, type-length,
+// payload-length, type). A prior off-by-one counted 3, so NLEN under-reported
+// by one and the record was malformed — Android tap-to-open, Chrome Web NFC,
+// and TagInfo's NDEF parser all rejected it ("No NDEF Data Storage Populated").
+TEST(BuildNdefTemplate, NlenAndSizeMatchTheRecordLength) {
+  auto result = BuildNdefTemplate(kBaseUrl);
+  ASSERT_TRUE(result.ok());
+  const NdefTemplate& t = *result;
+
+  // payload = prefix(1) + base_url + "?picc="(6) + 32 + "&cmac="(6) + 16
+  const size_t payload_length = 1 + kBaseUrl.size() + kUrlSuffixLength;
+  const size_t expected_message_length = 4 + payload_length;
+
+  // NLEN (bytes 0-1, big-endian) must equal the record length.
+  const size_t nlen = (static_cast<size_t>(Byte(t, 0)) << 8) | Byte(t, 1);
+  EXPECT_EQ(nlen, expected_message_length);
+
+  // Total file = NLEN(2) + message; nothing truncated.
+  EXPECT_EQ(t.size, 2 + expected_message_length);
+}
+
+TEST(BuildNdefTemplate, RecordHeaderIsAWellKnownUriShortRecord) {
+  auto result = BuildNdefTemplate(kBaseUrl);
+  ASSERT_TRUE(result.ok());
+  const NdefTemplate& t = *result;
+
+  const size_t payload_length = 1 + kBaseUrl.size() + kUrlSuffixLength;
+
+  EXPECT_EQ(Byte(t, 2), 0xD1);                                 // flags MB+ME+SR
+  EXPECT_EQ(Byte(t, 3), 0x01);                                 // type length
+  EXPECT_EQ(Byte(t, 4), static_cast<uint8_t>(payload_length)); // SR payload len
+  EXPECT_EQ(Byte(t, 5), 0x55);                                 // 'U'
+  EXPECT_EQ(Byte(t, 6), 0x04);                                 // "https://"
+}
+
+// The final byte of the file must be the last char of the 16-char CMAC
+// placeholder — i.e. the write isn't cut short by the length off-by-one.
+TEST(BuildNdefTemplate, FullMessageIncludingFinalCmacByteFits) {
+  auto result = BuildNdefTemplate(kBaseUrl);
+  ASSERT_TRUE(result.ok());
+  const NdefTemplate& t = *result;
+  EXPECT_EQ(Byte(t, t.size - 1), static_cast<uint8_t>('0'));
+}
+
+TEST(BuildNdefTemplate, PlaceholderOffsetsPointAtZeros) {
+  auto result = BuildNdefTemplate(kBaseUrl);
+  ASSERT_TRUE(result.ok());
+  const NdefTemplate& t = *result;
+
+  // Layout: NLEN(2) D1 01 plen 55 04 <base_url> "?picc=" <32×'0'> "&cmac=" <16×'0'>
+  const size_t picc = 2 + 5 + kBaseUrl.size() + 6;
+  EXPECT_EQ(t.picc_data_offset, picc);
+  EXPECT_EQ(Byte(t, t.picc_data_offset), static_cast<uint8_t>('0'));
+
+  EXPECT_EQ(t.sdm_mac_offset, picc + 32 + 6);
+  EXPECT_EQ(Byte(t, t.sdm_mac_offset), static_cast<uint8_t>('0'));
+}
+
+TEST(BuildNdefTemplate, RejectsEmptyAndOverlongBaseUrl) {
+  EXPECT_FALSE(BuildNdefTemplate("").ok());
+  const std::string too_long(kMaxBaseUrlLength + 1, 'x');
+  EXPECT_FALSE(BuildNdefTemplate(too_long).ok());
+}
+
+}  // namespace
+}  // namespace maco::personalize::sdm


### PR DESCRIPTION
## Root cause

`BuildNdefTemplate` (`maco_firmware/apps/personalize/sdm_constants.cc`) computed the NDEF message length as `3 + payload_length`. An NDEF short-record header is **4 bytes** — flags (`D1`), type-length (`01`), payload-length (`plen`), type (`55`) — followed by the payload. Counting 3 means:

- `NLEN` (and the total file size) under-report by one byte.
- The record's declared payload length (`plen`) runs one byte past the actual message.
- The write loop, sized from the same total, drops the final `cmac` placeholder byte.

The result: a **malformed NDEF message** that every spec-compliant reader rejects — Android's tap-to-open dispatch, Chrome's Web NFC `NDEFReader` (`readingerror`), and even TagInfo's NDEF parser (**"No NDEF Data Storage Populated"**) — while the raw URL bytes are still visible in a low-level dump. This is why the admin Web NFC scan (#408) failed on every tap and why these tags never triggered the OS "open URL" prompt.

The placeholder offsets (`picc_data_offset`/`sdm_mac_offset`) were already correct, so the SDM mirror wrote `picc`/`cmac` to the right spots — only the NDEF *wrapper* length was wrong.

## Fix
`ndef_message_length = 4 + payload_length`. Confirmed against a reference URI record written by NXP TagWriter (payload length 22 → message size **26 = 4 + 22**). `sdm_constants.h` already documented the correct overhead (`kNdefOverhead = 7`); the `.cc` disagreed.

## Test
New `sdm_constants_test.cc` (host `pw_cc_test`, 5 cases) pins NLEN/size to `4 + payload_length`, checks the record header bytes, the final CMAC byte fits, and the placeholder offsets. Passes; would have failed on the old `3 +`.

## ⚠️ Operational follow-up
**Existing field tags are mis-personalized and must be re-personalized** after this ships (re-flash the personalizer to a P2, re-run each tag through it). Until then, tap-to-open / self-checkout and the admin Web NFC scan won't work on those tags. New tags personalized with this build will be correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)