### PR TITLE
fix(personalize): read real UID via terminal-key probe (restore IdentifyTag)

### DIFF
--- a/maco_firmware/apps/personalize/main.cc
+++ b/maco_firmware/apps/personalize/main.cc
@@ -95,6 +95,7 @@ void AppInit() {
   // Start coordinator — keys come from console over RPC, no cloud needed
   static maco::personalize::PersonalizeCoordinator coordinator(
       nfc_reader,
+      maco::system::GetDeviceSecrets(),
       maco::system::GetRandomGenerator(),
       pw::System().allocator());
   g_coordinator = &coordinator;

--- a/maco_firmware/apps/personalize/personalize_coordinator.cc
+++ b/maco_firmware/apps/personalize/personalize_coordinator.cc
@@ -17,9 +17,11 @@ namespace maco::personalize {
 
 PersonalizeCoordinator::PersonalizeCoordinator(
     nfc::NfcReader& reader,
+    secrets::DeviceSecrets& device_secrets,
     pw::random::RandomGenerator& rng,
     pw::allocator::Allocator& allocator)
     : reader_(reader),
+      device_secrets_(device_secrets),
       rng_(rng),
       coro_cx_(allocator) {}
 
@@ -140,64 +142,51 @@ pw::async2::Coro<pw::Status> PersonalizeCoordinator::Run(
 pw::async2::Coro<pw::Status> PersonalizeCoordinator::HandleTag(
     pw::async2::CoroContext cx,
     nfc::NfcTag& tag) {
-  // IdentifyTag still needs device_secrets for the terminal key probe.
-  // With the new architecture, the tag identifier uses the reader's
-  // factory-default key probe only (no terminal key check needed for
-  // classification — factory tags have default keys, MaCo tags don't).
-  // However, the existing IdentifyTag requires DeviceSecrets. Since we
-  // no longer have it, we do a simplified identification: try default key 0.
-  // If auth succeeds → factory tag. If fails → already personalized (MaCo)
-  // or unknown.
+  // Identify the tag and read its REAL 7-byte UID via GetCardUid. Factory
+  // tags authenticate with the default key 0; already-personalized (MaCo)
+  // tags authenticate with the provisioned terminal key (key 1, read from
+  // device secrets). This is critical: with Random-ID enabled, the
+  // anti-collision UID is a random 4-byte value, NOT the real UID — using it
+  // would diversify the per-UID keys against the wrong UID. If neither key
+  // authenticates, the tag is unknown and we abort rather than guess.
+  auto ident_result =
+      co_await IdentifyTag(cx, tag, reader_, device_secrets_, rng_);
+  if (!ident_result.ok()) {
+    SetError("Tag-Identifikation fehlgeschlagen");
+    StreamTagEvent(maco_TagEvent_EventType_PERSONALIZATION_FAILED,
+                   maco_TagEvent_TagType_TAG_UNKNOWN, tag.uid(),
+                   "Identification error");
+    co_return ident_result.status();
+  }
+  const TagIdentification& ident = *ident_result;
 
-  auto tag_info = TagInfoFromNfcTag(tag);
-  nfc::Ntag424Tag ntag(reader_, tag_info);
-
-  // Try to select the NTAG424 application
-  auto select_status = co_await ntag.SelectApplication(cx);
-  if (!select_status.ok()) {
+  if (ident.type == TagType::kUnknown) {
+    // Neither the default nor the terminal key authenticated.
     SetState(PersonalizeStateId::kUnknownTag);
     StreamTagEvent(maco_TagEvent_EventType_TAG_ARRIVED,
-                   maco_TagEvent_TagType_TAG_UNKNOWN,
-                   tag.uid(), "Not an NTAG424 tag");
+                   maco_TagEvent_TagType_TAG_UNKNOWN, tag.uid(),
+                   "Unbekannter Tag (Schlüssel passen nicht)");
     co_return pw::OkStatus();
   }
 
-  // Try authenticating with default key 0
-  constexpr std::array<std::byte, 16> kDefaultKey = {};
-  nfc::LocalKeyProvider default_provider(0, kDefaultKey, rng_);
-  auto auth_result = co_await ntag.Authenticate(cx, default_provider);
-
-  TagType tag_type;
-  std::array<std::byte, 7> uid_buffer{};
-  size_t uid_size = 0;
-
-  if (auth_result.ok()) {
-    // Default key works → factory tag
-    tag_type = TagType::kFactory;
-
-    // Get authenticated UID
-    auto uid_result = co_await ntag.GetCardUid(
-        cx, *auth_result, pw::ByteSpan(uid_buffer));
-    if (uid_result.ok()) {
-      uid_size = *uid_result;
-    } else {
-      // Fall back to anti-collision UID
-      auto ac_uid = tag.uid();
-      uid_size = std::min(ac_uid.size(), uid_buffer.size());
-      std::copy_n(ac_uid.begin(), uid_size, uid_buffer.begin());
-    }
-  } else {
-    // Default key failed → assume already personalized (MaCo tag)
-    tag_type = TagType::kMaCo;
-    auto ac_uid = tag.uid();
-    uid_size = std::min(ac_uid.size(), uid_buffer.size());
-    std::copy_n(ac_uid.begin(), uid_size, uid_buffer.begin());
+  if (ident.uid_size != maco::TagUid::kSize) {
+    // Authenticated, but GetCardUid did not return the real 7-byte UID.
+    // Never proceed with a partial UID — it would mis-diversify the keys.
+    SetError("Echte UID konnte nicht gelesen werden");
+    StreamTagEvent(maco_TagEvent_EventType_PERSONALIZATION_FAILED,
+                   ident.type == TagType::kFactory
+                       ? maco_TagEvent_TagType_TAG_FACTORY
+                       : maco_TagEvent_TagType_TAG_MACO,
+                   tag.uid(), "GetCardUid failed");
+    co_return pw::OkStatus();
   }
 
-  auto stream_tag_type = tag_type == TagType::kFactory
+  const std::array<std::byte, 7>& uid_buffer = ident.uid;
+  const size_t uid_size = ident.uid_size;
+  auto stream_tag_type = ident.type == TagType::kFactory
                              ? maco_TagEvent_TagType_TAG_FACTORY
                              : maco_TagEvent_TagType_TAG_MACO;
-  auto screen_state = tag_type == TagType::kFactory
+  auto screen_state = ident.type == TagType::kFactory
                           ? PersonalizeStateId::kFactoryTag
                           : PersonalizeStateId::kMacoTag;
 

--- a/maco_firmware/apps/personalize/personalize_coordinator.h
+++ b/maco_firmware/apps/personalize/personalize_coordinator.h
@@ -22,6 +22,10 @@
 #include "pw_sync/interrupt_spin_lock.h"
 #include "pw_sync/lock_annotations.h"
 
+namespace maco::secrets {
+class DeviceSecrets;
+}
+
 namespace maco::personalize {
 
 /// Orchestrates NFC tag identification, key provisioning, and SDM
@@ -29,6 +33,7 @@ namespace maco::personalize {
 class PersonalizeCoordinator {
  public:
   PersonalizeCoordinator(nfc::NfcReader& reader,
+                         secrets::DeviceSecrets& device_secrets,
                          pw::random::RandomGenerator& rng,
                          pw::allocator::Allocator& allocator);
 
@@ -72,6 +77,7 @@ class PersonalizeCoordinator {
                       std::string_view message) PW_LOCKS_EXCLUDED(lock_);
 
   nfc::NfcReader& reader_;
+  secrets::DeviceSecrets& device_secrets_;
   pw::random::RandomGenerator& rng_;
 
   pw::async2::CoroContext coro_cx_;


### PR DESCRIPTION
## Symptom
Personalizing an already-personalized (Random-ID) tag showed a **4-byte random UID** (`08 1D CA FD` — the `0x08` anti-collision prefix) instead of the real 7-byte UID. Keys diversified against that UID would never verify.

## Root cause
`PersonalizeCoordinator::HandleTag` had an inline identification that only authenticated with the **default key 0**; on failure it fell back to the **anti-collision UID**. With Random-ID enabled, the anti-collision UID is random, so MaCo (already-personalized) tags were identified by the wrong UID.

The correct logic already existed in `IdentifyTag` (factory→default key, MaCo→terminal key from `DeviceSecretsEeprom`, both via `GetCardUid`), but it was **orphaned**: the terminal-key probe + `device_secrets` were removed from the coordinator in **`fc4ac49` (2026-02-18, "Console-driven tag personalization (remove Firebase/gateway dependency)")**. That refactor aimed to drop the *cloud* dependency, but device secrets are **local EEPROM**, not Firebase/gateway — so the probe was collateral damage and has been latent for ~4 months (it only matters when re-personalizing a MaCo tag).

## Fix
Re-inject `secrets::DeviceSecrets&` into the coordinator and call the existing `IdentifyTag`:
- **Factory** tag → auth default key 0 → `GetCardUid` → real UID.
- **MaCo** tag → auth terminal key (key 1, read locally from `DeviceSecretsEeprom`) → `GetCardUid` → real UID.
- **Neither** → `kUnknownTag`, **abort** (no UID guessing). Also aborts if `GetCardUid` doesn't return a 7-byte UID.

Downstream (`UpdateKeys`, SDM, NDEF) is already idempotent for re-personalization, so no other changes. No Firebase/gateway dependency is reintroduced — the terminal key is read from local flash.

## Verification
- `./pw build p2` ✅ (personalize firmware links).
- On-device (pending, yours): re-personalize a MaCo tag → state shows the real 7-byte UID, personalization completes.

Pairs with #410 (NDEF length fix) to make re-personalizing existing field tags work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)