### PR TITLE
fix(checkout): route verifyTagCheckout through authCall callable

### DIFF
--- a/checkout-kiosk/README.md
+++ b/checkout-kiosk/README.md
@@ -67,7 +67,7 @@ constants.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BRIDGE_KIOSK_URL` | `https://localhost:5173/?kiosk` | Base URL for the checkout web app. |
-| `BRIDGE_BEARER_KEY` | `""` | Per-build Bearer secret. **The build fails** when the URL points at a non-localhost host and this is empty. Web app sends it as `Authorization: Bearer …` to backend endpoints that decode the tag (`/api/verifyTagCheckout` today). The dev/emulator path bypasses the check, so empty is fine on localhost. |
+| `BRIDGE_BEARER_KEY` | `""` | Per-build Bearer secret. **The build fails** when the URL points at a non-localhost host and this is empty. The web app includes it in the `authCall/verifyTagCheckout` callable payload to decode the tag. The dev/emulator path bypasses the check, so empty is fine on localhost. |
 
 Label printing is handled by the `maco_gateway` (printer host configured
 there), not this bridge — see the printing-via-gateway plan and

--- a/docs/adr/0022-kiosk-badge-session-model.md
+++ b/docs/adr/0022-kiosk-badge-session-model.md
@@ -84,12 +84,12 @@ The transaction serializes concurrent calls with the same picc, so two parallel 
 
 ### 3. Per-kiosk Bearer on `verifyTagCheckout`
 
-The endpoint is registered with a per-route middleware that requires `Authorization: Bearer ${KIOSK_BEARER_KEY}` in production (emulator bypass via `FUNCTIONS_EMULATOR === "true"`). The Electron app reads the secret from env (client-side env var `BRIDGE_BEARER_KEY` since #314 — server-side Functions secret name `KIOSK_BEARER_KEY` is unchanged) and exposes it to the renderer via `contextBridge` IPC; the web app's `useTokenAuth` reads it via `window.bridge.bearer()` and sets the header.
+`verifyTagCheckout` is a callable routed through the `authCall` dispatcher (ADR-0028); it was moved off a raw Express route so it shares the SDK's automatic CORS handling. The kiosk bearer (`KIOSK_BEARER_KEY`) is carried as a field in the call payload and validated server-side in production (emulator bypass via `FUNCTIONS_EMULATOR === "true"`). The Electron app reads the secret from env (client-side env var `BRIDGE_BEARER_KEY` since #314 — server-side Functions secret name `KIOSK_BEARER_KEY` is unchanged) and exposes it to the renderer via `contextBridge` IPC; the web app's `useTokenAuth` reads it via `window.bridge.bearer()` and includes it in the payload.
 
 **This is intentionally not real attestation.** Anyone with local admin on the kiosk Windows box can extract the secret. Its actual value:
 - **Audit:** every accepted call is logged with `kioskId`.
 - **Revocation:** rotate the secret if leaked.
-- **Default rejection of phone taps:** a phone-opened SDM URL has no Bearer; the request 401s. Phones used to mint sessions; now they can't.
+- **Default rejection of phone taps:** a phone-opened SDM URL carries no bearer; the call is rejected with `permission-denied`. Phones used to mint sessions; now they can't.
 
 For real kiosk attestation we'd need TPM-anchored mTLS, a YubiKey/FIDO2 hardware key, or routing the call through the gateway (which already holds `GATEWAY_API_KEY` and lives on a more controlled machine). The plan tracks this as Phase F, deferred. The structural defense in §1 means a leaked Bearer doesn't grant anything more than a captured URL would — a narrow checkout-only session.
 

--- a/docs/adr/0028-grouped-callable-dispatchers.md
+++ b/docs/adr/0028-grouped-callable-dispatchers.md
@@ -38,9 +38,8 @@ function modules, and ES modules evaluate those dependencies *before* the
 `import "./options"` as the first line guarantees that.
 
 Client side targets the same region: `getFunctions(app, "europe-west6")`, the
-`verifyTagCheckout` raw-fetch `VITE_FUNCTIONS_REGION` default, the gateway
-`firebaseUrl`, and the test/env fixtures. The production region lives in the
-operations repo config (`firebase.region`, `gateway.firebaseUrl`).
+gateway `firebaseUrl`, and the test/env fixtures. The production region lives in
+the operations repo config (`firebase.region`, `gateway.firebaseUrl`).
 
 ### Grouping — four domain dispatchers
 
@@ -49,7 +48,7 @@ functions, one per domain:
 
 | Dispatcher | Methods |
 |---|---|
-| `authCall` | createUser, requestLoginCode, verifyLoginCode, verifyMagicLink |
+| `authCall` | createUser, requestLoginCode, verifyLoginCode, verifyMagicLink, resolveTag, verifyTagCheckout |
 | `membershipCall` | purchase/invite/accept/reject/revoke/remove/createChild/cancel/cancelAutoRenew + the two admin ops |
 | `billingCall` | getInvoiceDownloadUrl, getPaymentQrData, closeCheckoutAndGetPayment, acknowledgeBill |
 | `catalogCall` | upsertCatalogItem, getPriceListPdfUrl |

--- a/functions/src/auth/dispatcher.ts
+++ b/functions/src/auth/dispatcher.ts
@@ -12,12 +12,14 @@ import { resendApiKey } from "../util/resend_template";
 import {
   terminalKey,
   diversificationMasterKey,
+  kioskBearerKey,
 } from "../config/tag-secrets";
 import { createUserHandler } from "./create-user";
 import { requestLoginCodeHandler } from "./login-code/request";
 import { verifyLoginCodeHandler } from "./login-code/verify-code";
 import { verifyMagicLinkHandler } from "./login-code/verify-link";
 import { resolveTagHandler } from "./resolve-tag";
+import { verifyTagCheckoutHandler } from "../checkout/verify_tag";
 
 const HANDLERS: Record<string, RpcHandler> = {
   createUser: createUserHandler,
@@ -25,14 +27,16 @@ const HANDLERS: Record<string, RpcHandler> = {
   verifyLoginCode: verifyLoginCodeHandler,
   verifyMagicLink: verifyMagicLinkHandler,
   resolveTag: resolveTagHandler,
+  verifyTagCheckout: verifyTagCheckoutHandler,
 };
 
 export const authCall = onCall(
   {
-    // resendApiKey: login-code emails. terminalKey + master key: resolveTag
-    // decrypts the tapped tag's PICC. DIVERSIFICATION_SYSTEM_NAME is a
-    // defineString param (not a secret), so it needs no entry here.
-    secrets: [resendApiKey, terminalKey, diversificationMasterKey],
+    // resendApiKey: login-code emails. terminalKey + master key: resolveTag +
+    // verifyTagCheckout decrypt the tapped tag's PICC. kioskBearerKey: soft
+    // gate for verifyTagCheckout. DIVERSIFICATION_SYSTEM_NAME is a defineString
+    // param (not a secret), so it needs no entry here.
+    secrets: [resendApiKey, terminalKey, diversificationMasterKey, kioskBearerKey],
     memory: "512MiB",
   },
   (request) => dispatchRpc("auth", HANDLERS, request)

--- a/functions/src/checkout/verify_tag.ts
+++ b/functions/src/checkout/verify_tag.ts
@@ -9,8 +9,15 @@ import * as crypto from "crypto";
 import { getFirestore } from "firebase-admin/firestore";
 import { getAuth } from "firebase-admin/auth";
 import * as logger from "firebase-functions/logger";
+import { CallableRequest, HttpsError } from "firebase-functions/v2/https";
 import { decryptPICCData, verifyCMAC, PICCData } from "../ntag/sdm_crypto";
 import { diversifyKey } from "../ntag/key_diversification";
+import {
+  terminalKey,
+  diversificationMasterKey,
+  diversificationSystemName,
+  kioskBearerKey,
+} from "../config/tag-secrets";
 
 /**
  * Configuration passed from middleware
@@ -229,3 +236,42 @@ export async function handleVerifyTagCheckout(
     activeMembership: !!userData?.activeMembership,
   };
 }
+
+/**
+ * Callable wrapper for the kiosk tag-tap checkout. Routed via the `authCall`
+ * dispatcher so it shares CORS handling with every other web callable (no raw
+ * Express endpoint, no hand-rolled preflight). The `bearer` is a soft
+ * revocation/audit gate carried in the payload (the kiosk Electron bridge
+ * supplies it); the real security is the SDM tag crypto + the synthetic-UID
+ * custom token. Skipped in the emulator so E2E needs no secret in seed data.
+ */
+export const verifyTagCheckoutHandler = async (
+  request: CallableRequest<VerifyTagRequest & { bearer?: string }>
+): Promise<VerifyTagResponse> => {
+  const { picc, cmac, bearer } = request.data ?? ({} as VerifyTagRequest);
+
+  if (
+    process.env.FUNCTIONS_EMULATOR !== "true" &&
+    bearer !== kioskBearerKey.value()
+  ) {
+    logger.warn("verifyTagCheckout rejected: missing/invalid kiosk bearer.");
+    throw new HttpsError("permission-denied", "Forbidden");
+  }
+
+  try {
+    return await handleVerifyTagCheckout(
+      { picc, cmac },
+      {
+        terminalKey: terminalKey.value(),
+        masterKey: diversificationMasterKey.value(),
+        systemName: diversificationSystemName.value(),
+      }
+    );
+  } catch (error: any) {
+    logger.error("Tag verification failed", { error: error?.message });
+    throw new HttpsError(
+      "invalid-argument",
+      error?.message || "Tag verification failed"
+    );
+  }
+};

--- a/functions/src/config/tag-secrets.ts
+++ b/functions/src/config/tag-secrets.ts
@@ -20,3 +20,9 @@ export const diversificationMasterKey = defineSecret("DIVERSIFICATION_MASTER_KEY
 export const diversificationSystemName = defineString(
   "DIVERSIFICATION_SYSTEM_NAME"
 );
+
+// Soft revocation/audit knob for the kiosk's verifyTagCheckout call. NOT real
+// kiosk attestation — extracting this from a public Windows machine is trivial.
+// The actual security is the synthetic-UID custom token returned by
+// verifyTagCheckout (see checkout/verify_tag.ts).
+export const kioskBearerKey = defineSecret("KIOSK_BEARER_KEY");

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -22,7 +22,6 @@ import { handleTerminalCheckin } from "./auth/handle_terminal_checkin";
 import { handleAuthenticateTag } from "./auth/handle_authenticate_tag";
 import { handleCompleteTagAuth } from "./auth/handle_complete_tag_auth";
 import { handleUploadUsage } from "./session/handle_upload_usage";
-import { handleVerifyTagCheckout } from "./checkout/verify_tag";
 import {
   terminalKey,
   diversificationMasterKey,
@@ -33,69 +32,9 @@ import { BinaryWriter } from "@bufbuild/protobuf/wire";
 initializeApp();
 
 const gatewayApiKey = defineSecret("GATEWAY_API_KEY");
-// Soft revocation/audit knob for the kiosk's verifyTagCheckout call. NOT real
-// kiosk attestation — extracting this from a public Windows machine is
-// trivial. The actual security is the synthetic-UID custom token returned by
-// verifyTagCheckout (see checkout/verify_tag.ts).
-const kioskBearerKey = defineSecret("KIOSK_BEARER_KEY");
 
 export const app = express();
 app.use(express.json());
-
-// Per-route middleware for the public verifyTagCheckout endpoint. Bearer is
-// required in production; emulator mode skips it so E2E doesn't need the
-// secret baked into seed data.
-const kioskAuthMiddleware = (
-  req: express.Request,
-  res: express.Response,
-  next: express.NextFunction
-) => {
-  if (process.env.FUNCTIONS_EMULATOR === "true") {
-    next();
-    return;
-  }
-
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    logger.warn("Kiosk request missing Authorization header.");
-    res.status(401).send({ error: "Unauthorized" });
-    return;
-  }
-
-  const token = authHeader.split(" ")[1];
-  if (token !== kioskBearerKey.value()) {
-    logger.warn("Kiosk request with invalid Bearer.");
-    res.status(403).send({ error: "Forbidden" });
-    return;
-  }
-
-  // Tag the request with kiosk identity for audit-friendly logging downstream.
-  // Single-kiosk deployment for now; revisit when more kiosks are provisioned.
-  (req as { kioskId?: string }).kioskId = "kiosk-1";
-  next();
-};
-
-export const verifyTagCheckoutHandler = async (
-  req: express.Request,
-  res: express.Response
-) => {
-  try {
-    const result = await handleVerifyTagCheckout(req.body, {
-      terminalKey: terminalKey.value(),
-      masterKey: diversificationMasterKey.value(),
-      systemName: diversificationSystemName.value(),
-    });
-
-    res.status(200).contentType("application/json").send(result);
-  } catch (error: any) {
-    logger.error("Tag verification failed", { error: error.message });
-    res.status(400).contentType("application/json").send({
-      error: error.message || "Tag verification failed",
-    });
-  }
-};
-
-app.post("/verifyTagCheckout", kioskAuthMiddleware, verifyTagCheckoutHandler);
 
 // Authentication middleware - accepts Particle webhook key or gateway key.
 const authMiddleware = (
@@ -251,12 +190,7 @@ function sendProtoResponse<T>(
 
 export const api = onRequest(
   {
-    secrets: [
-      diversificationMasterKey,
-      gatewayApiKey,
-      terminalKey,
-      kioskBearerKey,
-    ],
+    secrets: [diversificationMasterKey, gatewayApiKey, terminalKey],
     memory: "512MiB",
   },
   app

--- a/functions/test/integration/verify-tag-checkout-callable.test.ts
+++ b/functions/test/integration/verify-tag-checkout-callable.test.ts
@@ -1,0 +1,165 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+// Covers the `verifyTagCheckoutHandler` callable wrapper (not the pure
+// `handleVerifyTagCheckout`, which is exercised by verify-tag-checkout.test.ts).
+// The wrapper adds the kiosk-bearer gate, HttpsError mapping, and reads the
+// SDM keys from defineSecret/defineString params — `.value()` reads
+// process.env directly in the local test runtime, so we prime the env here.
+import { expect } from "chai";
+import type { CallableRequest } from "firebase-functions/v2/https";
+import {
+  setupEmulator,
+  clearFirestore,
+  teardownEmulator,
+  seedTestData,
+} from "../emulator-helper";
+import { verifyTagCheckoutHandler } from "../../src/checkout/verify_tag";
+import { generateValidPICCAndCMAC } from "../test-sdm-helper";
+
+describe("verifyTagCheckoutHandler (callable wrapper, Integration)", () => {
+  const TEST_TOKEN_UID = "04c339aa1e1890";
+  const TEST_USER_ID = "testUser123";
+  const TEST_TERMINAL_KEY = "00112233445566778899aabbccddeeff";
+  const TEST_MASTER_KEY = "fedcba9876543210fedcba9876543210";
+  const TEST_SYSTEM_NAME = "test-system";
+  const TEST_BEARER = "test-kiosk-bearer";
+
+  const savedEnv: Record<string, string | undefined> = {};
+
+  before(async function () {
+    this.timeout(10000);
+    await setupEmulator();
+    for (const k of [
+      "TERMINAL_KEY",
+      "DIVERSIFICATION_MASTER_KEY",
+      "DIVERSIFICATION_SYSTEM_NAME",
+      "KIOSK_BEARER_KEY",
+      "FUNCTIONS_EMULATOR",
+    ]) {
+      savedEnv[k] = process.env[k];
+    }
+    process.env.TERMINAL_KEY = TEST_TERMINAL_KEY;
+    process.env.DIVERSIFICATION_MASTER_KEY = TEST_MASTER_KEY;
+    process.env.DIVERSIFICATION_SYSTEM_NAME = TEST_SYSTEM_NAME;
+    process.env.KIOSK_BEARER_KEY = TEST_BEARER;
+  });
+
+  after(async () => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await teardownEmulator();
+  });
+
+  beforeEach(async () => {
+    process.env.FUNCTIONS_EMULATOR = "true";
+    await clearFirestore();
+  });
+
+  function makeRequest(data: {
+    picc?: string;
+    cmac?: string;
+    bearer?: string;
+  }): CallableRequest<{ picc: string; cmac: string; bearer?: string }> {
+    return { data } as CallableRequest<{
+      picc: string;
+      cmac: string;
+      bearer?: string;
+    }>;
+  }
+
+  async function seedValidToken() {
+    await seedTestData({
+      tokens: {
+        [TEST_TOKEN_UID]: {
+          userId: `/users/${TEST_USER_ID}`,
+          label: "Test Token",
+        },
+      },
+      users: {
+        [TEST_USER_ID]: {
+          firstName: "Test",
+          lastName: "User",
+          name: "Test User Full Name",
+          permissions: [],
+          roles: ["member"],
+        },
+      },
+    });
+    return generateValidPICCAndCMAC(
+      TEST_TOKEN_UID,
+      0,
+      TEST_TERMINAL_KEY,
+      TEST_MASTER_KEY,
+      TEST_SYSTEM_NAME
+    );
+  }
+
+  it("emulator mode bypasses the bearer and returns a custom token", async () => {
+    const { picc, cmac } = await seedValidToken();
+
+    const response = await verifyTagCheckoutHandler(makeRequest({ picc, cmac }));
+
+    expect(response).to.have.property("userId", TEST_USER_ID);
+    expect(response).to.have.property("customToken").that.is.a("string");
+  });
+
+  it("maps handler failures to HttpsError(invalid-argument)", async () => {
+    // No seeded token → handleVerifyTagCheckout throws "Token not found",
+    // which the wrapper must re-throw as an HttpsError.
+    const { picc, cmac } = generateValidPICCAndCMAC(
+      TEST_TOKEN_UID,
+      0,
+      TEST_TERMINAL_KEY,
+      TEST_MASTER_KEY,
+      TEST_SYSTEM_NAME
+    );
+
+    try {
+      await verifyTagCheckoutHandler(makeRequest({ picc, cmac }));
+      expect.fail("expected HttpsError");
+    } catch (err: any) {
+      expect(err.code).to.equal("invalid-argument");
+      expect(err.message).to.include("Token not found");
+    }
+  });
+
+  describe("production bearer gate (FUNCTIONS_EMULATOR off)", () => {
+    beforeEach(() => {
+      process.env.FUNCTIONS_EMULATOR = "";
+    });
+
+    it("rejects a missing bearer with permission-denied", async () => {
+      try {
+        await verifyTagCheckoutHandler(makeRequest({ picc: "x", cmac: "y" }));
+        expect.fail("expected HttpsError");
+      } catch (err: any) {
+        expect(err.code).to.equal("permission-denied");
+      }
+    });
+
+    it("rejects a wrong bearer with permission-denied", async () => {
+      try {
+        await verifyTagCheckoutHandler(
+          makeRequest({ picc: "x", cmac: "y", bearer: "nope" })
+        );
+        expect.fail("expected HttpsError");
+      } catch (err: any) {
+        expect(err.code).to.equal("permission-denied");
+      }
+    });
+
+    it("accepts the correct bearer and proceeds to verification", async () => {
+      const { picc, cmac } = await seedValidToken();
+
+      const response = await verifyTagCheckoutHandler(
+        makeRequest({ picc, cmac, bearer: TEST_BEARER })
+      );
+
+      expect(response).to.have.property("userId", TEST_USER_ID);
+      expect(response).to.have.property("customToken").that.is.a("string");
+    });
+  });
+});

--- a/web/modules/lib/rpc.ts
+++ b/web/modules/lib/rpc.ts
@@ -39,6 +39,7 @@ export const RpcMethod = {
     "verifyLoginCode",
     "verifyMagicLink",
     "resolveTag",
+    "verifyTagCheckout",
   ],
   membershipCall: [
     "purchaseMembership",

--- a/web/modules/lib/token-auth.ts
+++ b/web/modules/lib/token-auth.ts
@@ -10,6 +10,7 @@ import {
 } from "firebase/auth"
 import { useFunctions, useFirebaseAuth } from "./firebase-context"
 import { resolveBridgeBearer } from "./use-bridge"
+import { rpcCallable } from "./rpc"
 
 export interface TokenUser {
   tokenId: string
@@ -35,17 +36,6 @@ interface UseTokenAuthResult {
   isTagAuth: boolean
   /** Sign out of the tag-created Firebase Auth session */
   tagSignOut: () => Promise<void>
-}
-
-const FUNCTIONS_REGION = import.meta.env.VITE_FUNCTIONS_REGION ?? "europe-west6"
-
-/** Build the base URL for the Functions endpoint. */
-function functionsBaseUrl(projectId: string | undefined): string {
-  if (import.meta.env.DEV) {
-    const port = import.meta.env.VITE_EMULATOR_FUNCTIONS_PORT || "5001"
-    return `http://127.0.0.1:${port}/${import.meta.env.VITE_FIREBASE_PROJECT_ID}/${FUNCTIONS_REGION}`
-  }
-  return `https://${FUNCTIONS_REGION}-${projectId}.cloudfunctions.net`
 }
 
 interface VerifyTagResponse {
@@ -99,7 +89,6 @@ export function useTokenAuth(
     setLoading(true)
     setError(null)
 
-    const url = `${functionsBaseUrl(functions.app.options.projectId)}/api/verifyTagCheckout`
     let cancelled = false
 
     ;(async () => {
@@ -108,24 +97,21 @@ export function useTokenAuth(
         let pending = inflightVerifyByKey.get(cacheKey)
         if (!pending) {
           pending = (async () => {
-            const headers: Record<string, string> = {
-              "Content-Type": "application/json",
-            }
+            // Goes through the authCall dispatcher like every other web
+            // callable, so CORS is handled by the Firebase SDK. The kiosk
+            // bearer (soft revocation/audit gate) rides in the payload — the
+            // Electron bridge supplies it; a normal browser sends none.
             const bearer = await resolveBridgeBearer()
-            if (bearer) headers["Authorization"] = `Bearer ${bearer}`
-
-            const res = await fetch(url, {
-              method: "POST",
-              headers,
-              body: JSON.stringify({ picc, cmac }),
+            const verifyTagCheckout = rpcCallable<
+              { picc: string; cmac: string; bearer?: string },
+              VerifyTagResponse
+            >(functions, "authCall", "verifyTagCheckout")
+            const res = await verifyTagCheckout({
+              picc,
+              cmac,
+              bearer: bearer ?? undefined,
             })
-            const responseBody = await res.json()
-            if (!res.ok) {
-              throw new Error(
-                responseBody.error ?? "Tag-Verifizierung fehlgeschlagen"
-              )
-            }
-            return responseBody as VerifyTagResponse
+            return res.data
           })()
           inflightVerifyByKey.set(cacheKey, pending)
           // Drop the cache entry once settled so a fresh tap (after tagSignOut)


### PR DESCRIPTION
## Problem

Kiosk NFC tag checkout was broken in production. Tapping a tag read fine and navigated the web app to `/checkin?picc=…&cmac=…`, but the user was never registered — the browser blocked the call with a CORS preflight failure on `…/api/verifyTagCheckout`.

**Root cause:** `verifyTagCheckout` was the *only* web→function call using a hand-rolled `fetch()` to the raw Express `api` endpoint, which has no CORS handling. Every other web call goes through the grouped callable dispatchers (ADR-0028), and Firebase callables answer CORS automatically. The raw endpoint existed so the kiosk could send an `Authorization: Bearer` header — but that bearer is, per its own code comment, a *soft revocation/audit knob, not real attestation* (the real security is the SDM tag crypto + the returned synthetic-UID custom token).

## Change

Convert `verifyTagCheckout` into a callable handler in the existing `authCall` dispatcher, like every other web call. This removes the CORS problem at the root and deletes the off-pattern raw endpoint. The kiosk bearer is **preserved** — it now rides in the callable payload (validated server-side, skipped in the emulator), keeping the kiosk-only gating + audit/revocation.

- `config/tag-secrets.ts` — `kioskBearerKey` moved here so the dispatcher can import it
- `checkout/verify_tag.ts` — new thin `verifyTagCheckoutHandler` wrapping the unchanged pure `handleVerifyTagCheckout` (bearer gate + `HttpsError` mapping)
- `auth/dispatcher.ts` — register `verifyTagCheckout`, add `kioskBearerKey` secret
- `index.ts` — delete the raw route, `kioskAuthMiddleware`, and the secret usage
- `web/modules/lib/rpc.ts` / `token-auth.ts` — raw fetch → `rpcCallable(... "authCall", "verifyTagCheckout")`, bearer in payload; in-flight dedup kept
- Docs: ADR-0022 §3, ADR-0028 (region clause + authCall table), checkout-kiosk README updated to the callable mechanism

Precedent: `verifyLoginCodeHandler` is already an anonymous callable returning a `customToken`.

## Testing

- `functions`: build ✅, **212 tests pass** ✅ — incl. a new `verify-tag-checkout-callable.test.ts` covering the bearer gate (emulator bypass, missing/wrong/correct bearer) and error mapping
- `web`: build ✅, **569 unit tests pass** ✅
- **NFC tag checkout E2E ✅** (`checkout-nfc-tag.spec.ts`, both viewports) — drives the browser through `/checkin` → callable → functions emulator → signed-in user (the exact flow that was broken)

## Deploy note

`KIOSK_BEARER_KEY` now binds to `authCall` (not `api`) via the dispatcher's `secrets` array — confirm it's bound at deploy time, or the prod bearer check will reject kiosk calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)