### PR TITLE
fix(kiosk): keep verifying text centered during badge-box height tween

### DIFF
--- a/web/apps/checkout/src/components/checkout/nfc-badge-affordance.tsx
+++ b/web/apps/checkout/src/components/checkout/nfc-badge-affordance.tsx
@@ -80,11 +80,16 @@ export function NfcBadgeAffordance({
       // error interrupts (role="alert" + assertive).
       role={mode === "verifying" ? "status" : mode === "error" ? "alert" : undefined}
       aria-live={mode === "error" ? "assertive" : undefined}
-      className={`overflow-hidden transition-all duration-450 ${CONTAINER_CLASSES[mode]}`}
+      // flex/justify-center vertically centres the layer against the
+      // container's *live* animated height every frame. An inner h-full
+      // percentage chain did not track the height tween — the content pinned
+      // to the top while the box grew, then snapped to centre the instant the
+      // animation finished.
+      className={`flex flex-col justify-center overflow-hidden transition-all duration-450 ${CONTAINER_CLASSES[mode]}`}
     >
       {/* key={mode} remounts the layer so tw-animate's fade-in plays on
           every state switch while the container height/color tweens. */}
-      <div key={mode} className="h-full animate-in fade-in duration-300">
+      <div key={mode} className="w-full animate-in fade-in duration-300">
         {mode === "hero" && <HeroLayer />}
         {mode === "compact" && <CompactLayer />}
         {mode === "verifying" && <VerifyingLayer />}
@@ -135,7 +140,7 @@ function HeroLayer() {
 
 function CompactLayer() {
   return (
-    <div className="flex h-full items-center gap-3 px-4 text-cog-teal">
+    <div className="flex items-center gap-3 px-4 text-cog-teal">
       <MiniFobIcon />
       <span className="text-[13.5px] text-muted-foreground">
         Badge an den Leser halten, um deine Daten zu laden
@@ -146,7 +151,7 @@ function CompactLayer() {
 
 function VerifyingLayer() {
   return (
-    <div className="flex h-full items-center gap-4 px-6 text-white">
+    <div className="flex items-center gap-4 px-6 text-white">
       <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/25">
         <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
       </span>


### PR DESCRIPTION
## Problem

On the kiosk check-in badge affordance, when the box grows into the
**verifying** state (compact → "Badge erkannt", 450ms height tween), the
progress text was pinned to the **top** of the box for the whole growth,
then snapped to vertically-centered the instant the tween finished — a
visible jumpcut.

## Cause

The content was centered via an inner `h-full` percentage-height chain
(`height: 100%` against the animating container). That chain doesn't
track a `transition`-animated parent height, so the content sat at its
natural top position during growth and only resolved to centered at rest.

## Fix

Center the layer with flexbox on the animating container itself
(`flex flex-col justify-center`) and drop the `h-full` chain. Flex
recomputes the cross-axis position against the container's live animated
height every frame, so the text stays centered throughout the tween.
Rest-state layout (and the e2e screenshot baselines) is unchanged.

## Not included

The separate report — "a badge that **fails to read** shows a toast
instead of inline" — is intentionally left as-is. That path is the
unrouteable-tag handler in `BridgeNfcRouter` (fires at the app root,
before any tag reaches the wizard), and the decision is to keep the
toast on all steps; only verify-RPC failures use the inline box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)