### PR TITLE
test(web): fix flaky input-otp 'window is not defined' teardown crash

### DIFF
--- a/web/modules/test/setup.ts
+++ b/web/modules/test/setup.ts
@@ -1,6 +1,7 @@
 // Copyright Offene Werkstatt Wädenswil
 // SPDX-License-Identifier: MIT
 
+import { afterAll } from "vitest"
 import "@testing-library/jest-dom/vitest"
 
 // jsdom lacks ResizeObserver and elementFromPoint; input-otp (segmented code
@@ -16,3 +17,17 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 if (typeof document !== "undefined" && !document.elementFromPoint) {
   document.elementFromPoint = () => null
 }
+
+// input-otp@1.4.2 schedules setTimeout(0/10/50ms) from a mount effect and
+// never clears them (only its password-manager-badge timers get cleaned up).
+// If a straggler fires *after* Vitest tears down the jsdom `window` at
+// end-of-file, its setState reaches React's scheduler, which reads `window`
+// to resolve update priority → an unhandled "window is not defined" that
+// fails the whole file even though every test passed. Draining pending
+// macrotasks once per file (window still alive, components already unmounted
+// by cleanup) lets those timers fire harmlessly before teardown. Runs once
+// per test file, so the cost is negligible. Remove once input-otp ships the
+// missing effect cleanup.
+afterAll(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 55))
+})


### PR DESCRIPTION
## Problem

The web unit suite intermittently failed with an unhandled error even though **every test passed**:

```
Vitest caught 1 unhandled error during the test run.
ReferenceError: window is not defined
  ❯ resolveUpdatePriority  react-dom-client.development.js
  ❯ dispatchSetState       react-dom-client.development.js
  ❯ Timeout._onTimeout     node_modules/input-otp/dist/index.mjs
This error originated in "src/components/checkout/checkin-signin.test.tsx"
```

This reddened unrelated PRs that touch `firestore/` or `scripts/` (the path selector runs the web suite for those) — e.g. it failed the initial run of #509.

## Root cause

`input-otp@1.4.2` schedules `setTimeout(0/10/50ms)` from a mount effect via its internal `ht()` helper and **never clears them** (only its password-manager-badge timers are cleaned up on unmount). When a straggler fires *after* Vitest tears down the jsdom `window` at end-of-file, its `setState` reaches React's scheduler — which reads `window` to resolve update priority — and throws.

Proven deterministically with a throwaway probe: an `OTPInput` leaves timers pending (`getTimerCount() > 0`) after `unmount()`.

## Fix

A per-file `afterAll` in the shared web test setup (`web/modules/test/setup.ts`, which already owns input-otp's jsdom compat shims) drains pending macrotasks once — window still alive, components already unmounted by `cleanup` — so those timers fire harmlessly before teardown. Runs once per file, so wall-clock cost is negligible.

No test-body changes; fixes every OTP-rendering file, not just `checkin-signin`. Remove once input-otp ships the missing effect cleanup.

## Testing

- Deterministic probe confirms the leak (timers survive unmount).
- Full checkout suite green: **68 files / 705 tests**, no unhandled errors; admin 25, web integration 141 — all pass.
- Local repro of the race isn't reliable (it's CI-load/teardown-timing specific), which is exactly why the root-cause fix (drain-before-teardown) is the right remedy rather than a retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)