### PR TITLE
feat(checkout): direct-priced (Pauschal CHF) pinned machine rows

### DIFF
--- a/scripts/seed-data/seed-public/config-pricing.json
+++ b/scripts/seed-data/seed-public/config-pricing.json
@@ -9,7 +9,7 @@
     "holz":       { "label": "Holz",              "order": 1, "pinnedMachines": ["dfoYVuO3bhRJoRCbgND1", "LZ04lfdfdEieqQOsKhzi"] },
     "metall":     { "label": "Metall",            "order": 2, "pinnedMachines": ["7SlZb0jUKcyE8sMcvyzD", "kcspOmeZ3lsj4hNfHD4V"] },
     "textil":     { "label": "Textil",            "order": 3 },
-    "keramik":    { "label": "Keramik",           "order": 4 },
+    "keramik":    { "label": "Keramik",           "order": 4, "pinnedMachines": ["r0Okgv7FkK6Ip0ndMPrB"] },
     "schmuck":    { "label": "Schmuck",           "order": 5, "pinnedMachines": ["tot0yitdBPf2hseDSuFf"] },
     "glas":       { "label": "Glas",              "order": 6, "pinnedMachines": ["17mC1Qe4xn2dfGNpsdfo"] },
     "stein":      { "label": "Stein",             "order": 7, "pinnedMachines": ["ljE5dcV7qDv0Z50BdwHY"] },

--- a/web/apps/checkout/src/components/usage/inline-rows.browser.test.tsx
+++ b/web/apps/checkout/src/components/usage/inline-rows.browser.test.tsx
@@ -171,6 +171,7 @@ function renderSection(props: {
   discountLevel?: DiscountLevel
   checkoutId?: string | null
   onAddMaterial?: () => void
+  pinnedCatalog?: CatalogItem[]
 }) {
   const callbacks = props.callbacks ?? makeCallbacks()
   const onAddMaterial = props.onAddMaterial ?? (() => {})
@@ -182,10 +183,44 @@ function renderSection(props: {
       callbacks={callbacks}
       checkoutId={props.checkoutId ?? null}
       onAddMaterial={onAddMaterial}
+      discountLevel={props.discountLevel}
+      pinnedCatalog={props.pinnedCatalog}
     />,
     { wrapper: FirebaseWrapper },
   )
   return { callbacks, onAddMaterial }
+}
+
+/** Hourly pinned machine (issue #105): hours × CHF/Std. */
+function makeHourlyMachine(): CatalogItem {
+  return {
+    id: "cat-hourly",
+    code: "0001",
+    name: "Drechselbank",
+    workshops: ["holz"],
+    category: ["Maschinen"],
+    variants: [
+      { id: "default", pricingModel: "time", unitPrice: { default: 10, member: 8 } },
+    ],
+    active: true,
+    userCanAdd: true,
+  }
+}
+
+/** Direct-priced pinned machine (issue #555): user enters the CHF amount. */
+function makeDirectMachine(): CatalogItem {
+  return {
+    id: "cat-brennen",
+    code: "0011",
+    name: "Brennen",
+    workshops: ["holz"],
+    category: ["Maschinen"],
+    variants: [
+      { id: "pauschal", pricingModel: "direct", unitPrice: { default: 0 } },
+    ],
+    active: true,
+    userCanAdd: true,
+  }
 }
 
 /**
@@ -236,6 +271,67 @@ describe("WorkshopInlineSection v5", () => {
     expect(screen.getByText("Zwischentotal Holz")).toBeTruthy()
     // 5 + 10 = 15.00
     expect(screen.getByText(/CHF\s*15\.00/)).toBeTruthy()
+  })
+
+  it("pinned hourly machine multiplies typed hours by the rate", async () => {
+    const user = userEvent.setup()
+    const { callbacks } = renderSection({ pinnedCatalog: [makeHourlyMachine()] })
+    expect(screen.getByText("10.00/Std.")).toBeTruthy()
+    await user.type(screen.getByLabelText("Stunden Drechselbank"), "1.5")
+    await user.tab()
+    expect(callbacks.addItem).toHaveBeenCalledTimes(1)
+    expect(callbacks.addItem.mock.calls[0][0]).toMatchObject({
+      type: "machine",
+      catalogId: "cat-hourly",
+      pricingModel: "time",
+      quantity: 1.5,
+      unitPrice: 10,
+      totalPrice: 15,
+      formInputs: [{ quantity: 1.5, unit: "h" }],
+    })
+  })
+
+  it("pinned direct machine (Pauschal CHF) commits the typed amount (issue #555)", async () => {
+    const user = userEvent.setup()
+    const { callbacks } = renderSection({ pinnedCatalog: [makeDirectMachine()] })
+    // Direct rows show a CHF field and "Pauschal" instead of an hourly rate.
+    expect(screen.getByText("Pauschal")).toBeTruthy()
+    expect(screen.getByText("CHF")).toBeTruthy()
+    await user.type(screen.getByLabelText("Betrag Brennen"), "12.5")
+    await user.tab()
+    expect(callbacks.addItem).toHaveBeenCalledTimes(1)
+    expect(callbacks.addItem.mock.calls[0][0]).toMatchObject({
+      type: "machine",
+      catalogId: "cat-brennen",
+      pricingModel: "direct",
+      quantity: 1,
+      unitPrice: 12.5,
+      totalPrice: 12.5,
+    })
+  })
+
+  it("clearing a pinned direct field removes the committed item", async () => {
+    const user = userEvent.setup()
+    const committed = makeItem({
+      id: "i-brennen",
+      type: "machine",
+      catalogId: "cat-brennen",
+      pricingModel: "direct",
+      quantity: 1,
+      unitPrice: 12.5,
+      totalPrice: 12.5,
+      description: "Brennen",
+    })
+    const { callbacks } = renderSection({
+      items: [committed],
+      pinnedCatalog: [makeDirectMachine()],
+    })
+    // Field syncs from the committed item's amount (not its quantity of 1).
+    const field = screen.getByLabelText("Betrag Brennen")
+    expect((field as HTMLInputElement).value).toBe("12.5")
+    await user.clear(field)
+    await user.tab()
+    expect(callbacks.removeItem).toHaveBeenCalledWith("i-brennen")
   })
 
   it("hides the machine container when no NFC items exist", () => {

--- a/web/apps/checkout/src/components/usage/inline-rows.tsx
+++ b/web/apps/checkout/src/components/usage/inline-rows.tsx
@@ -346,26 +346,29 @@ export function WorkshopInlineSection({
     setExpandedNfc((m) => ({ ...m, [id]: !m[id] }))
   }
 
-  // Pinned machines (issue #105): an always-visible hours input per MaCo-less
+  // Pinned machines (issue #105): an always-visible input per MaCo-less
   // machine, rendered as ordinary rows in the shared "Maschinen / Werkzeuge"
-  // table (Menge holds the input, Kosten the /Std. rate, Preis the live
-  // total). Hours text lives here (keyed by catalogId) so Preis updates as
-  // the user types; it's synced from the committed item while the field is
-  // unfocused (SpendeCard pattern) and committed on blur.
+  // table (Menge holds the input, Kosten the rate, Preis the live total).
+  // Hourly machines take hours (× CHF/Std.); direct-model machines (Pauschal
+  // CHF, e.g. Keramik-Brennen, issue #555) take the CHF amount itself. The
+  // field text lives here (keyed by catalogId) so Preis updates as the user
+  // types; it's synced from the committed item while the field is unfocused
+  // (SpendeCard pattern) and committed on blur.
   const pinnedItemByCatalog = useMemo(() => {
     const m = new Map<string, CheckoutItemLocal>()
     for (const i of machineItems) if (i.catalogId) m.set(i.catalogId, i)
     return m
   }, [machineItems])
-  const [pinnedHours, setPinnedHours] = useState<Record<string, string>>({})
+  const [pinnedText, setPinnedText] = useState<Record<string, string>>({})
   const pinnedFocusRef = useRef<string | null>(null)
   useEffect(() => {
-    setPinnedHours((prev) => {
+    setPinnedText((prev) => {
       let changed = false
       const next = { ...prev }
       for (const cat of pinnedCatalog) {
         if (pinnedFocusRef.current === cat.id) continue
-        const q = pinnedItemByCatalog.get(cat.id)?.quantity ?? 0
+        const item = pinnedItemByCatalog.get(cat.id)
+        const q = isDirectPinned(cat) ? (item?.totalPrice ?? 0) : (item?.quantity ?? 0)
         const canonical = q > 0 ? String(q) : ""
         const parsed = parseFloat((prev[cat.id] ?? "").replace(",", ".")) || 0
         if (parsed !== q) {
@@ -380,26 +383,34 @@ export function WorkshopInlineSection({
   const commitPinned = (cat: CatalogItem, unitPrice: number) => {
     pinnedFocusRef.current = null
     const variant = primaryVariant(cat)
-    const hours = Math.max(
+    const direct = isDirectPinned(cat)
+    // Hourly: the field holds hours. Direct: it IS the CHF amount from the
+    // workshop's price note (issue #555) — quantity 1, unitPrice = total,
+    // mirroring the picker's DirectForm item shape.
+    const value = Math.max(
       0,
-      parseFloat((pinnedHours[cat.id] ?? "").replace(",", ".")) || 0,
+      parseFloat((pinnedText[cat.id] ?? "").replace(",", ".")) || 0,
     )
-    const total = Math.round(hours * unitPrice * 100) / 100
+    const total = Math.round((direct ? value : value * unitPrice) * 100) / 100
     const existing = pinnedItemByCatalog.get(cat.id)
-    if (hours <= 0) {
+    if (value <= 0) {
       if (existing) callbacks.removeItem(existing.id)
-      setPinnedHours((p) => ({ ...p, [cat.id]: "" }))
+      setPinnedText((p) => ({ ...p, [cat.id]: "" }))
       return
     }
+    const priced = direct
+      ? { quantity: 1, unitPrice: total, totalPrice: total }
+      : {
+          quantity: value,
+          unitPrice,
+          totalPrice: total,
+          formInputs: [{ quantity: value, unit: "h" }],
+        }
     if (existing) {
-      if (existing.quantity === hours) return
-      callbacks.updateItem(existing.id, {
-        ...existing,
-        quantity: hours,
-        unitPrice,
-        totalPrice: total,
-        formInputs: [{ quantity: hours, unit: "h" }],
-      })
+      if (direct ? existing.totalPrice === total : existing.quantity === value) {
+        return
+      }
+      callbacks.updateItem(existing.id, { ...existing, ...priced })
     } else {
       callbacks.addItem({
         id: crypto.randomUUID(),
@@ -410,39 +421,38 @@ export function WorkshopInlineSection({
         catalogId: cat.id,
         variantId: variant?.id ?? "default",
         pricingModel: variant?.pricingModel ?? "time",
-        quantity: hours,
-        unitPrice,
-        totalPrice: total,
-        formInputs: [{ quantity: hours, unit: "h" }],
+        ...priced,
       })
     }
   }
 
   const pinnedRows: PositionRow[] = pinnedCatalog.map((cat) => {
     const variant = primaryVariant(cat)
+    const direct = isDirectPinned(cat)
     const unitPrice = variant ? priceForTier(variant.unitPrice, discountLevel) : 0
-    const text = pinnedHours[cat.id] ?? ""
-    const hours = Math.max(0, parseFloat(text.replace(",", ".")) || 0)
-    const total = Math.round(hours * unitPrice * 100) / 100
+    const text = pinnedText[cat.id] ?? ""
+    const value = Math.max(0, parseFloat(text.replace(",", ".")) || 0)
+    const total = Math.round((direct ? value : value * unitPrice) * 100) / 100
     return {
       key: cat.id,
       title: cat.name,
       subtitle: null,
       menge: (
-        <PinnedHoursField
+        <PinnedValueField
           value={text}
-          label={cat.name}
+          ariaLabel={`${direct ? "Betrag" : "Stunden"} ${cat.name}`}
+          suffix={direct ? "CHF" : "Std."}
           onFocus={() => {
             pinnedFocusRef.current = cat.id
           }}
-          onChange={(v) => setPinnedHours((p) => ({ ...p, [cat.id]: v }))}
+          onChange={(v) => setPinnedText((p) => ({ ...p, [cat.id]: v }))}
           onBlur={() => commitPinned(cat, unitPrice)}
         />
       ),
-      kosten: `${unitPrice.toFixed(2)}/Std.`,
+      kosten: direct ? "Pauschal" : `${unitPrice.toFixed(2)}/Std.`,
       preis: total.toFixed(2),
       // Always-shown input rows aren't removable via the (×); clearing the
-      // hours to 0 removes the underlying item instead.
+      // field to 0 removes the underlying item instead.
       removable: false,
     }
   })
@@ -551,35 +561,45 @@ export function WorkshopInlineSection({
 
 // ---------------------------------------------------------------------------
 // Pinned machine rows (issue #105). For machines without a MaCo, the cost
-// step shows an always-visible hours input so visitors can record usage
-// manually. Each pinned machine is a catalog item referenced from
+// step shows an always-visible input so visitors can record usage manually.
+// Each pinned machine is a catalog item referenced from
 // `config/pricing.workshops[ws].pinnedMachines`; the row IS the
-// representation of its checkout item — entering hours upserts it, clearing
-// removes it.
+// representation of its checkout item — entering a value upserts it,
+// clearing removes it. Hourly machines take hours; direct-model machines
+// (Pauschal CHF) take the amount itself (issue #555).
 // ---------------------------------------------------------------------------
+
+/** A pinned machine whose primary variant is direct-priced (Pauschal CHF):
+ *  the visitor enters the amount, not hours (issue #555). */
+function isDirectPinned(cat: CatalogItem): boolean {
+  return primaryVariant(cat)?.pricingModel === "direct"
+}
 
 /** Digits with at most one `.`/`,` separator and decimals; empty allowed so
  *  the field can be cleared. A `type="text"` input is used deliberately:
  *  `type="number"` returns "" from `e.target.value` mid-decimal (e.g. "1."),
  *  which silently swallowed fractional hours (issue #105). */
-const HOURS_TYPING_PATTERN = /^(?:|\d*(?:[.,]\d*)?)$/
+const PINNED_TYPING_PATTERN = /^(?:|\d*(?:[.,]\d*)?)$/
 
 /**
- * Editable hours cell for a pinned machine (issue #105), rendered in the
+ * Editable value cell for a pinned machine (issue #105), rendered in the
  * shared PositionTable's Menge column so it lines up with NFC machine rows
  * (which show "X Min") and material rows. Controlled by WorkshopInlineSection
  * — the Preis column reflects the live value — and commits on blur. Accepts
- * fractional hours (e.g. 1.5).
+ * decimals (e.g. 1.5 hours, 12.50 CHF); `suffix` names the unit ("Std." for
+ * hourly machines, "CHF" for direct-priced ones).
  */
-function PinnedHoursField({
+function PinnedValueField({
   value,
-  label,
+  ariaLabel,
+  suffix,
   onFocus,
   onChange,
   onBlur,
 }: {
   value: string
-  label: string
+  ariaLabel: string
+  suffix: string
   onFocus: () => void
   onChange: (v: string) => void
   onBlur: () => void
@@ -590,18 +610,18 @@ function PinnedHoursField({
         type="text"
         inputMode="decimal"
         value={value}
-        aria-label={`Stunden ${label}`}
+        aria-label={ariaLabel}
         placeholder="0"
         onFocus={onFocus}
         onChange={(e) => {
           const raw = e.target.value
-          if (!HOURS_TYPING_PATTERN.test(raw)) return
+          if (!PINNED_TYPING_PATTERN.test(raw)) return
           onChange(raw)
         }}
         onBlur={onBlur}
         className="h-8 w-16 rounded-[3px] border border-[#ccc] bg-background px-2 text-right text-sm tabular-nums text-foreground outline-none focus:border-cog-teal"
       />
-      <span className="text-xs text-muted-foreground">Std.</span>
+      <span className="text-xs text-muted-foreground">{suffix}</span>
     </span>
   )
 }


### PR DESCRIPTION
## What

Pinned machine rows on the cost step (issue #105) were hardwired to hourly semantics — hours input × `CHF/Std.` rate — so a `pricingModel: "direct"` machine couldn't be pinned (it would render an hours field against a 0 rate, always totalling CHF 0).

When the pinned variant is direct, the always-visible field now takes the **CHF amount itself**: the committed item gets `quantity: 1, unitPrice = totalPrice = amount`, mirroring the picker's `DirectForm` item shape, and the Kosten column shows *Pauschal* instead of an hourly rate. Hourly machines are unchanged.

This enables the Keramik **Brennen** flow (#555): the kiln operator writes the firing price on the note with the object; the visitor types that amount on the cost step. The Brennen SKU (`0011`, added in #514) is now pinned via `workshops.keramik.pinnedMachines` in the public pricing seed (operations seed updated in parallel).

## Tests

Three new browser tests in `inline-rows.browser.test.tsx`: hourly pinned rows still multiply hours × rate; direct pinned rows commit the typed amount with the DirectForm shape; clearing a direct field removes the committed item (field syncs from `totalPrice`, not `quantity`).

Closes #555

## Note

Based on `feat/staging-env-overlay` (#514) because the Brennen SKU seed lives there — GitHub will retarget to `main` when #514 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qBSBsBX5zkrJr6hxCaFBL