### PR TITLE
fix(checkout): use real Farbkonzept OWW colors for workshop dots

### DIFF
--- a/web/apps/checkout/src/routes/_authenticated/account/usage.tsx
+++ b/web/apps/checkout/src/routes/_authenticated/account/usage.tsx
@@ -544,14 +544,20 @@ function toJsDate(
   return value.toDate()
 }
 
+// Farbkonzept OWW (2026-01-14) — one color per Werkstatt, see
+// `--color-ws-*` tokens in web/modules/index.css. "diverses" is a
+// catch-all bucket, not a real workshop, so it isn't listed here — it
+// falls through to the default color in workshopColor below.
 const WORKSHOP_PALETTE: Record<string, string> = {
-  laser: "#3aa8b1",
-  holz: "#cf6e3a",
-  fdm: "#7a5cb5",
-  sla: "#7a5cb5",
-  metall: "#8a8378",
-  textil: "#d4a017",
-  keramik: "#a86f5a",
+  holz: "var(--color-ws-holz)",
+  keramik: "var(--color-ws-keramik)",
+  metall: "var(--color-ws-metall)",
+  textil: "var(--color-ws-textil)",
+  schmuck: "var(--color-ws-schmuck)",
+  glas: "var(--color-ws-glas)",
+  stein: "var(--color-ws-stein)",
+  malen: "var(--color-ws-malen)",
+  makerspace: "var(--color-ws-makerspace)",
 }
 
 function workshopColor(id: string): string {

--- a/web/modules/index.css
+++ b/web/modules/index.css
@@ -59,6 +59,17 @@
   --color-twint-red: #ed1c24;
   --color-fee-good: var(--color-cog-teal-dark);
   --color-fee-warn: var(--color-oww-gold-dark);
+  /* Farbkonzept OWW (2026-01-14) — one color per Werkstatt. Holz reuses
+     OWW Gold; Textil matches Cog Teal. */
+  --color-ws-holz: var(--color-oww-gold);
+  --color-ws-keramik: #f39a83;
+  --color-ws-metall: #8baddc;
+  --color-ws-textil: var(--color-cog-teal);
+  --color-ws-schmuck: #4dc685;
+  --color-ws-glas: #e77676;
+  --color-ws-stein: #9ebac0;
+  --color-ws-malen: #cb9cdc;
+  --color-ws-makerspace: #a44d6e;
   --font-family-heading: "Bitter", Georgia, serif;
   --font-family-body: "Roboto Slab", "Helvetica Neue", sans-serif;
   --animate-caret-blink: caret-blink 1.25s ease-out infinite;


### PR DESCRIPTION
## Summary
- `usage.tsx`'s `WORKSHOP_PALETTE` used made-up hex codes keyed by ids that aren't real workshops (`laser`, `fdm`, `sla`), while missing half of the actual 9 Werkstätten (`schmuck`, `glas`, `stein`, `malen`, `makerspace`).
- Added the brand's `--color-ws-*` tokens to `web/modules/index.css`, sourced from the "Farbkonzept OWW" (2026-01-14) design doc in the claude.ai design-system project — these tokens didn't exist in the codebase yet.
- Rewired the palette to the correct 9 workshop ids (matching `WorkshopId` / seeded `config/pricing.workshops`); `diverses` is a catch-all bucket, not a real workshop, so it falls through to the existing default color.

## Test plan
- [x] `npm run test:precommit` (web build, unit tests, integration tests) — all passing, ran automatically via pre-commit hook
- [x] `vite build` for checkout app — confirmed `--color-ws-*` tokens compile into the CSS bundle correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qBSBsBX5zkrJr6hxCaFBL