### PR TITLE
fix(membership): make pending family invites visible to signed-in invitees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,8 @@ New screenshot tests automatically run at both viewports — no extra configurat
 - `functions/src/**/*.test.ts` — Functions unit tests (Mocha)
 - `functions/test/integration/` — Functions integration tests (Mocha + emulator)
 
+**The Firestore emulator does not enforce indexes.** A `collectionGroup(...)` query needs a `COLLECTION_GROUP`-scope entry in `firestore/firestore.indexes.json` `fieldOverrides` (pattern: `items.tokenId`, `invites.email`) or it throws `FAILED_PRECONDITION` on real projects — while passing every emulator-backed test. When adding a collection-group query, add the fieldOverride in the same PR and deploy with `firebase deploy --only firestore:indexes` to both projects. (This shipped a broken pending-invites banner past the full test suite in July 2026.)
+
 **When adding a new owner-scoped Firestore collection,** add cross-user negative tests to `web/modules/test/cross-user-rules.integration.test.ts` (matrix: other-user read/write/delete, anon, tag-tap, admin carve-out). This file is the regression net for the B2 launch-readiness incident (cross-user `checkouts` read leak) — it must fail loudly if any owner-scoped rule is ever loosened.
 
 ## Web Application

--- a/docs/adr/0025-async-mutation-error-handling.md
+++ b/docs/adr/0025-async-mutation-error-handling.md
@@ -63,6 +63,14 @@ public surface (`set` / `add` / `update` / `remove` / `mutate`, plus
   is the second line of redaction server-side.
 - A telemetry failure MUST NOT recurse or affect the re-thrown
   original error.
+- The same contract covers background *reads* whose failures degrade
+  to an empty UI instead of a toast: `reportQueryError`
+  (`web/modules/lib/firestore.ts`) for Firestore listeners and
+  `reportRpcError` (`web/modules/lib/rpc.ts`) for fetch-and-degrade
+  RPCs (e.g. the pending-invites banner). A `catch` that renders a
+  fallback state MUST report through one of these — a swallowed error
+  once hid a missing-index outage entirely (family-invite incident,
+  2026-07).
 
 ## Consequences
 

--- a/firestore/firestore.indexes.json
+++ b/firestore/firestore.indexes.json
@@ -267,6 +267,28 @@
       "indexes": []
     },
     {
+      "collectionGroup": "invites",
+      "fieldPath": "email",
+      "indexes": [
+        {
+          "queryScope": "COLLECTION",
+          "order": "ASCENDING"
+        },
+        {
+          "queryScope": "COLLECTION",
+          "order": "DESCENDING"
+        },
+        {
+          "queryScope": "COLLECTION",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "queryScope": "COLLECTION_GROUP",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "printJobs",
       "fieldPath": "ttlAt",
       "ttl": true,

--- a/functions/test/integration/invite-receiving.test.ts
+++ b/functions/test/integration/invite-receiving.test.ts
@@ -8,6 +8,7 @@ process.env.FUNCTIONS_EMULATOR = "true";
 
 import { expect } from "chai";
 import { Timestamp, type DocumentReference } from "firebase-admin/firestore";
+import type { CallableRequest } from "firebase-functions/v2/https";
 import {
   setupEmulator,
   clearFirestore,
@@ -16,6 +17,7 @@ import {
 } from "../emulator-helper";
 import { handleGetFamilyInviteInfo } from "../../src/membership/invite_info";
 import { handleAcceptInviteNewAccount } from "../../src/membership/accept_invite_new_account";
+import { listMyFamilyInvitesHandler } from "../../src/membership/list_my_invites";
 import type {
   MembershipEntity,
   MembershipInviteEntity,
@@ -396,6 +398,76 @@ describe("Family invite receiving (Integration)", () => {
             "https://evil.example.com",
           ),
         "failed-precondition",
+      );
+    });
+  });
+
+  describe("listMyFamilyInvites", () => {
+    function authedRequest(email: string | null): CallableRequest<unknown> {
+      return {
+        data: {},
+        auth: { uid: "invitee-uid", token: email ? { email } : {} },
+      } as unknown as CallableRequest<unknown>;
+    }
+
+    it("lists a pending invite addressed to the token email", async () => {
+      const { membershipId, inviteId } = await seed("listed@example.com");
+      const result = await listMyFamilyInvitesHandler(
+        authedRequest("listed@example.com"),
+      );
+      expect(result.invites).to.have.length(1);
+      expect(result.invites[0]).to.deep.equal({
+        membershipId,
+        inviteId,
+        inviterName: "Anna Müller",
+      });
+    });
+
+    it("matches the token email case-insensitively", async () => {
+      await seed("mixedcase@example.com");
+      const result = await listMyFamilyInvitesHandler(
+        authedRequest("MixedCase@Example.com"),
+      );
+      expect(result.invites).to.have.length(1);
+    });
+
+    it("excludes invites addressed to other emails", async () => {
+      await seed("someone-else@example.com");
+      const result = await listMyFamilyInvitesHandler(
+        authedRequest("me@example.com"),
+      );
+      expect(result.invites).to.have.length(0);
+    });
+
+    it("excludes non-pending invites", async () => {
+      await seed("resolved@example.com", { status: "accepted" });
+      const result = await listMyFamilyInvitesHandler(
+        authedRequest("resolved@example.com"),
+      );
+      expect(result.invites).to.have.length(0);
+    });
+
+    it("excludes TTL-expired invites", async () => {
+      await seed("expired@example.com", { ttlMs: -1000 });
+      const result = await listMyFamilyInvitesHandler(
+        authedRequest("expired@example.com"),
+      );
+      expect(result.invites).to.have.length(0);
+    });
+
+    it("returns an empty list when the token carries no email", async () => {
+      await seed("no-email-token@example.com");
+      const result = await listMyFamilyInvitesHandler(authedRequest(null));
+      expect(result.invites).to.have.length(0);
+    });
+
+    it("rejects unauthenticated calls", async () => {
+      await expectHttpsError(
+        () =>
+          listMyFamilyInvitesHandler({
+            data: {},
+          } as unknown as CallableRequest<unknown>),
+        "unauthenticated",
       );
     });
   });

--- a/web/apps/checkout/src/routes/_authenticated/account/membership.tsx
+++ b/web/apps/checkout/src/routes/_authenticated/account/membership.tsx
@@ -15,7 +15,7 @@ import {
   Users,
   X,
 } from "lucide-react"
-import { rpcCallable } from "@modules/lib/rpc"
+import { rpcCallable, reportRpcError } from "@modules/lib/rpc"
 import { where } from "firebase/firestore"
 import * as React from "react"
 import { z } from "zod"
@@ -293,7 +293,14 @@ function WrongAccountInviteNotice() {
       .then(({ data }) => {
         if (!cancelled) setEmail(data.status === "pending" ? data.email : null)
       })
-      .catch(() => {
+      .catch((err) => {
+        reportRpcError(
+          functions,
+          "checkout.wrongAccountInviteNotice",
+          "membershipCall",
+          "getFamilyInviteInfo",
+          err,
+        )
         if (!cancelled) setEmail(null)
       })
     return () => {
@@ -310,11 +317,16 @@ function WrongAccountInviteNotice() {
 
   const handleSwitch = () =>
     switchMutation.mutate(async () => {
-      await signOut()
+      // Navigate to the (public) invite page FIRST — if signOut flips `user`
+      // to null while we're still under _authenticated, the unauth gate
+      // bounces to /login?redirect=<pathname>, which drops the ?invite=
+      // search param and loses the invite context. Same pattern as the
+      // sidebar sign-out in authenticated-layout.tsx.
       navigate({
         to: "/account/invite/$membershipId/$inviteId",
         params: { membershipId, inviteId },
       })
+      await signOut()
     })
 
   return (
@@ -378,7 +390,16 @@ function PendingInvitesBanner() {
       .then(({ data }) => {
         if (!cancelled) setCards(data.invites)
       })
-      .catch(() => {
+      .catch((err) => {
+        // Degrading to "no invites" hides real failures (a missing index
+        // made pending invites silently invisible once) — report them.
+        reportRpcError(
+          functions,
+          "checkout.pendingInvitesBanner",
+          "membershipCall",
+          "listMyFamilyInvites",
+          err,
+        )
         if (!cancelled) setCards([])
       })
     return () => {

--- a/web/apps/checkout/src/routes/_authenticated/account/membership.tsx
+++ b/web/apps/checkout/src/routes/_authenticated/account/membership.tsx
@@ -322,6 +322,12 @@ function WrongAccountInviteNotice() {
       // bounces to /login?redirect=<pathname>, which drops the ?invite=
       // search param and loses the invite context. Same pattern as the
       // sidebar sign-out in authenticated-layout.tsx.
+      //
+      // Ordering caveat: the invite page's own redirect effect would send a
+      // still-signed-in wrong-account user straight back here. It doesn't,
+      // only because its `ready` gate waits on the getFamilyInviteInfo
+      // round-trip while signOut() is a local auth-state flip that wins that
+      // race. If signOut ever grows a network step, revisit this.
       navigate({
         to: "/account/invite/$membershipId/$inviteId",
         params: { membershipId, inviteId },

--- a/web/apps/checkout/src/routes/account/invite/$membershipId/$inviteId.tsx
+++ b/web/apps/checkout/src/routes/account/invite/$membershipId/$inviteId.tsx
@@ -26,7 +26,7 @@ import { signInWithCustomToken } from "firebase/auth"
 import { Loader2 } from "lucide-react"
 import { useAuth } from "@modules/lib/auth"
 import { useFirebaseAuth, useFunctions } from "@modules/lib/firebase-context"
-import { rpcCallable } from "@modules/lib/rpc"
+import { rpcCallable, reportRpcError } from "@modules/lib/rpc"
 import { useAsyncMutation } from "@modules/hooks/use-async-mutation"
 import {
   SignupFields,
@@ -85,7 +85,16 @@ function InviteAcceptPage() {
       .then(({ data }) => {
         if (!cancelled) setInfo(data)
       })
-      .catch(() => {
+      .catch((err) => {
+        // The fallback renders "Einladung nicht gefunden" — report the error
+        // so an infra failure (vs a genuinely missing invite) isn't silent.
+        reportRpcError(
+          functions,
+          "checkout.inviteAcceptPage",
+          "membershipCall",
+          "getFamilyInviteInfo",
+          err,
+        )
         if (!cancelled)
           setInfo({
             status: "not_found",

--- a/web/modules/lib/firestore.ts
+++ b/web/modules/lib/firestore.ts
@@ -58,7 +58,8 @@ function reportQueryError(
 ): void {
   const sessionId = getClientSessionId()
   const code = err.code ?? err.name ?? "unknown"
-  const message = err.message ?? String(err)
+  // Same 200-char cap as useAsyncMutation (ADR-0025); server caps again.
+  const message = (err.message ?? String(err)).slice(0, 200)
   // eslint-disable-next-line no-console
   console.error("[firestore] error", { path, code, message, sessionId })
 

--- a/web/modules/lib/rpc.test.ts
+++ b/web/modules/lib/rpc.test.ts
@@ -9,7 +9,8 @@ vi.mock("firebase/functions", () => ({
   httpsCallable: vi.fn(() => callableMock),
 }))
 
-import { prewarm, resetPrewarmForTest } from "./rpc"
+import { httpsCallable } from "firebase/functions"
+import { prewarm, reportRpcError, resetPrewarmForTest } from "./rpc"
 
 const functions = {} as Functions
 
@@ -59,5 +60,75 @@ describe("prewarm", () => {
     await vi.runAllTimersAsync()
     prewarm(functions, "authCall")
     expect(callableMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("reportRpcError", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    callableMock.mockReset()
+    callableMock.mockResolvedValue({ data: { ok: true } })
+    // Silence the intentional console.error in reportRpcError.
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleSpy.mockRestore()
+  })
+
+  it("sends the error to logClientError with group.method as path", () => {
+    reportRpcError(functions, "checkout.pendingInvitesBanner", "membershipCall", "listMyFamilyInvites", {
+      code: "failed-precondition",
+      message: "The query requires an index",
+    })
+    expect(vi.mocked(httpsCallable)).toHaveBeenCalledWith(
+      functions,
+      "logClientError",
+    )
+    expect(callableMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        context: "checkout.pendingInvitesBanner",
+        code: "failed-precondition",
+        message: "The query requires an index",
+        path: "membershipCall.listMyFamilyInvites",
+        sessionId: expect.any(String),
+      }),
+    )
+  })
+
+  it("falls back to name, then 'unknown', for the code", () => {
+    reportRpcError(functions, "ctx", "authCall", "resolveTag", new TypeError("boom"))
+    expect(callableMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ code: "TypeError", message: "boom" }),
+    )
+    reportRpcError(functions, "ctx", "authCall", "resolveTag", "plain string")
+    expect(callableMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ code: "unknown", message: "plain string" }),
+    )
+  })
+
+  it("caps the message at 200 chars", () => {
+    reportRpcError(functions, "ctx", "billingCall", "acknowledgeBill", {
+      message: "x".repeat(500),
+    })
+    const payload = callableMock.mock.lastCall?.[0] as { message: string }
+    expect(payload.message).toHaveLength(200)
+  })
+
+  it("never throws — not when the callable rejects, nor when it can't init", async () => {
+    callableMock.mockRejectedValueOnce(new Error("telemetry down"))
+    expect(() =>
+      reportRpcError(functions, "ctx", "authCall", "resolveTag", new Error("e")),
+    ).not.toThrow()
+    // Let the rejection propagate through the .catch handler.
+    await Promise.resolve()
+
+    vi.mocked(httpsCallable).mockImplementationOnce(() => {
+      throw new Error("init failure")
+    })
+    expect(() =>
+      reportRpcError(functions, "ctx", "authCall", "resolveTag", new Error("e")),
+    ).not.toThrow()
   })
 })

--- a/web/modules/lib/rpc.ts
+++ b/web/modules/lib/rpc.ts
@@ -17,6 +17,10 @@
  *
  * `RpcMethod` is the central registry of which method lives in which group —
  * the one place to look when adding or moving a callable.
+ *
+ * `reportRpcError` is the telemetry hook for background RPCs whose failures
+ * are otherwise swallowed (fetch-and-degrade UI); see ADR-0025 for the
+ * client-error telemetry contract.
  */
 
 import {
@@ -107,8 +111,12 @@ export function reportRpcError(
   const sessionId = getClientSessionId()
   const e = (err ?? {}) as { code?: unknown; name?: unknown; message?: unknown }
   const code = String(e.code ?? e.name ?? "unknown")
-  const message =
+  // Same 200-char cap as useAsyncMutation (ADR-0025): app-level errors could
+  // theoretically contain user data; the server caps again as second line of
+  // defence.
+  const message = (
     typeof e.message === "string" ? e.message : String(err)
+  ).slice(0, 200)
   const path = `${group}.${method}`
   // eslint-disable-next-line no-console
   console.error("[rpc] error", { path, context, code, message, sessionId })

--- a/web/modules/lib/rpc.ts
+++ b/web/modules/lib/rpc.ts
@@ -24,6 +24,7 @@ import {
   type Functions,
   type HttpsCallableResult,
 } from "firebase/functions"
+import { getClientSessionId } from "./client-session"
 
 export type RpcGroup =
   | "authCall"
@@ -87,6 +88,46 @@ export function rpcCallable<Req = unknown, Res = unknown>(
     group
   )
   return (payload: Req) => fn({ method, payload })
+}
+
+/**
+ * Fire-and-forget telemetry for a failed RPC whose error is otherwise
+ * swallowed by the caller (background fetches that degrade to an empty UI,
+ * like the pending-invites banner). Mirrors `reportQueryError` in
+ * `firestore.ts`: logs to console and to Cloud Logging via `logClientError`.
+ * Never throws. `context` must not contain user-specific values.
+ */
+export function reportRpcError(
+  functions: Functions,
+  context: string,
+  group: RpcGroup,
+  method: string,
+  err: unknown
+): void {
+  const sessionId = getClientSessionId()
+  const e = (err ?? {}) as { code?: unknown; name?: unknown; message?: unknown }
+  const code = String(e.code ?? e.name ?? "unknown")
+  const message =
+    typeof e.message === "string" ? e.message : String(err)
+  const path = `${group}.${method}`
+  // eslint-disable-next-line no-console
+  console.error("[rpc] error", { path, context, code, message, sessionId })
+
+  try {
+    httpsCallable(functions, "logClientError")({
+      sessionId,
+      context,
+      code,
+      message,
+      path,
+      userAgent:
+        typeof navigator !== "undefined" ? (navigator.userAgent ?? "") : "",
+    }).catch(() => {
+      // Swallow: telemetry failure must never surface to the UI.
+    })
+  } catch {
+    // Swallow synchronous init errors for the same reason.
+  }
 }
 
 // Keep-warm pings (ADR-0037). A dispatcher's first call of the day pays the


### PR DESCRIPTION
## Incident

On staging, a family-membership invitee who signed in (or already had a session) never saw their pending invite — only the "Mitglied werden" buy screen. The invite doc was intact and `pending` the whole time.

## Root causes & fixes

1. **Missing collection-group index** (`firestore/firestore.indexes.json`): `listMyFamilyInvites` runs a collection-group query on `invites.email`, which needs a `COLLECTION_GROUP`-scope fieldOverride. Without it the query throws `FAILED_PRECONDITION` on real projects — the emulator does not enforce indexes, so this passed all local testing. Added the override (default collection-scope indexes + collection-group ASC, mirroring `items.tokenId`).
   - Staging: already deployed and verified building.
   - **Prod: still needs `firebase deploy --only firestore:indexes --project oww-maco`.**

2. **Sign-out race dropped the invite context** (`membership.tsx` `handleSwitch`): awaiting `signOut()` before navigating let the `_authenticated` unauth gate bounce to `/login?redirect=<pathname>`, which drops the `?invite=` search param — the invitee then went through generic signup and never hit the invite-accept path. Now navigates to the public invite page first, then signs out (same documented pattern as the sidebar sign-out in `authenticated-layout.tsx`).

3. **Silently swallowed errors** hid the failure: `PendingInvitesBanner` and `WrongAccountInviteNotice` degraded to an empty UI on any RPC error. Added `reportRpcError` in `@modules/lib/rpc` (mirrors `reportQueryError`) and wired both catches to it, so these failures land in Cloud Logging via `logClientError`.

## Testing

- `npm run test:precommit` green (builds, web unit + integration, functions unit + integration).
- Verified on staging: invite doc `memberships/tG5k5omaEHBZHk6H3byZ/invites/…` still pending with correct normalized email; the `FAILED_PRECONDITION` in function logs matches the incident timeline; index override deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bASkoPUk1hd4cVAPMTBnA