### PR TITLE
fix(web): keep mobile form controls at 16px to stop iOS focus auto-zoom

### DIFF
--- a/web/apps/checkout/e2e/ios-input-zoom.spec.ts
+++ b/web/apps/checkout/e2e/ios-input-zoom.spec.ts
@@ -1,0 +1,181 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+/**
+ * Regression coverage for issue #492 — "Zu breit in iOS".
+ *
+ * iOS Safari auto-zooms the page when a focused form control's computed
+ * font-size is below 16px, and the zoom persists after blur — in an SPA it
+ * then survives navigation, so the whole app appears cropped/too wide on
+ * every subsequent page. The reported viewport (344px on a 393pt screen)
+ * matches a 16/14 zoom exactly: the signature of a focused 14px (text-sm)
+ * control.
+ *
+ * The zoom itself can't be reproduced in chromium, but its trigger condition
+ * can: at mobile widths, every focusable text-entry control must have a
+ * computed font-size of at least 16px. Desktop widths are exempt — the
+ * md:text-sm downshift is fine there because desktop browsers don't
+ * focus-zoom.
+ */
+
+import { test, expect, type Page } from "@playwright/test"
+import {
+  clearCollections,
+  getAdminFirestore,
+  waitForLoginCode,
+} from "./helpers"
+import { AUTH_USER_EMAIL, AUTH_USER_ID } from "./global-setup"
+import { FieldValue } from "firebase-admin/firestore"
+
+const MIN_FONT_PX = 16
+const CHECKOUT_ID = "e2e-ios-zoom-checkout-001"
+
+/**
+ * Collects every rendered control that would trigger the iOS focus zoom.
+ * Checkbox/radio and friends are exempt: they render no editable text, so
+ * iOS does not zoom them. Disabled controls can't receive focus.
+ */
+async function collectZoomTriggers(page: Page): Promise<string[]> {
+  return page.evaluate((min) => {
+    const EXEMPT_TYPES = new Set([
+      "checkbox",
+      "radio",
+      "hidden",
+      "range",
+      "file",
+      "button",
+      "submit",
+      "reset",
+      "image",
+      "color",
+    ])
+    const offenders: string[] = []
+    for (const el of Array.from(
+      document.querySelectorAll<HTMLElement>("input, select, textarea"),
+    )) {
+      const type = (el.getAttribute("type") ?? "text").toLowerCase()
+      if (el.tagName === "INPUT" && EXEMPT_TYPES.has(type)) continue
+      if ((el as HTMLInputElement).disabled) continue
+      if (!(el.checkVisibility?.() ?? true)) continue
+      const size = parseFloat(getComputedStyle(el).fontSize)
+      if (size < min) {
+        const label =
+          el.getAttribute("data-testid") ??
+          el.getAttribute("aria-label") ??
+          el.getAttribute("placeholder") ??
+          el.tagName.toLowerCase()
+        offenders.push(`${label} (${size}px)`)
+      }
+    }
+    return offenders
+  }, MIN_FONT_PX)
+}
+
+async function expectNoZoomTriggers(page: Page, context: string) {
+  expect(
+    await collectZoomTriggers(page),
+    `${context}: sub-16px focusable controls trigger the iOS auto-zoom (issue #492)`,
+  ).toEqual([])
+}
+
+async function signIn(page: Page) {
+  await page.goto("/login")
+  await page.getByTestId("login-email-input").fill(AUTH_USER_EMAIL)
+  await page.getByTestId("login-email-submit").click()
+  await expect(page.getByTestId("login-code-stage")).toBeVisible({
+    timeout: 5000,
+  })
+  const entry = await waitForLoginCode(AUTH_USER_EMAIL)
+  expect(entry).toBeTruthy()
+  await page.getByTestId("login-code-input").fill(entry!.code)
+  await page.getByTestId("login-code-submit").click()
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
+    timeout: 10_000,
+  })
+}
+
+async function seedOpenCheckout() {
+  const db = getAdminFirestore()
+  await db
+    .collection("checkouts")
+    .doc(CHECKOUT_ID)
+    .set({
+      userId: db.collection("users").doc(AUTH_USER_ID),
+      status: "open",
+      usageType: "regular",
+      created: FieldValue.serverTimestamp(),
+      workshopsVisited: ["makerspace"],
+      persons: [],
+    })
+}
+
+async function clearCheckoutFixture() {
+  const db = getAdminFirestore()
+  const checkoutRef = db.collection("checkouts").doc(CHECKOUT_ID)
+  const items = await checkoutRef.collection("items").get()
+  await Promise.all(items.docs.map((d) => d.ref.delete()))
+  await checkoutRef.delete().catch(() => {})
+}
+
+test.describe("iOS focus-zoom guard — no sub-16px controls at mobile widths (issue #492)", () => {
+  test.beforeEach(async ({ isMobile }) => {
+    test.skip(!isMobile, "iOS focus-zoom only matters at mobile widths")
+    await clearCollections("loginCodes")
+  })
+
+  test("sign-in surfaces (login page, check-in email + code dialog)", async ({
+    page,
+  }) => {
+    // /login email stage, then its code stage.
+    await page.goto("/login")
+    await expect(page.getByTestId("login-email-input")).toBeVisible()
+    await expectNoZoomTriggers(page, "/login email stage")
+
+    await page.getByTestId("login-email-input").fill(AUTH_USER_EMAIL)
+    await page.getByTestId("login-email-submit").click()
+    await expect(page.getByTestId("login-code-stage")).toBeVisible({
+      timeout: 5000,
+    })
+    await expectNoZoomTriggers(page, "/login code stage")
+
+    // Check-in identifier form (the surface in the issue screenshots), then
+    // the OTP dialog. The dialog's hidden input is the autoFocus timing
+    // hazard: input-otp sets its font-size from --root-height only after
+    // mount, so the inherited size the scan sees here is what iOS reads at
+    // focus time.
+    await clearCollections("loginCodes")
+    await page.goto("/checkin?kiosk")
+    await expect(page.getByTestId("checkin-identifier")).toBeVisible()
+    await expectNoZoomTriggers(page, "/checkin identifier form")
+
+    await page.getByTestId("checkin-identifier").fill(AUTH_USER_EMAIL)
+    await page.getByTestId("checkin-identifier-submit").click()
+    await expect(page.getByTestId("checkin-code-dialog")).toBeVisible({
+      timeout: 10_000,
+    })
+    await expectNoZoomTriggers(page, "/checkin code dialog")
+  })
+
+  test("material picker (search + quantity form)", async ({ page }) => {
+    await clearCheckoutFixture()
+    await seedOpenCheckout()
+    try {
+      await signIn(page)
+
+      // The page from the original report: picker sheet with autoFocus search.
+      await page.goto("/visit/add/workshop/makerspace")
+      const search = page.getByPlaceholder("Material suchen…")
+      await expect(search).toBeVisible({ timeout: 10_000 })
+      await expectNoZoomTriggers(page, "picker search")
+
+      // Open a material form — its quantity input also autoFocuses.
+      await page.getByText("Filament", { exact: true }).click()
+      await expect(page.locator('input[type="number"]').first()).toBeVisible({
+        timeout: 10_000,
+      })
+      await expectNoZoomTriggers(page, "picker quantity form")
+    } finally {
+      await clearCheckoutFixture()
+    }
+  })
+})

--- a/web/apps/checkout/src/components/checkout/checkin-signin.tsx
+++ b/web/apps/checkout/src/components/checkout/checkin-signin.tsx
@@ -396,7 +396,7 @@ export function CheckinSignin({
           }}
           disabled={busy}
           data-testid="checkin-identifier"
-          className="h-[42px] w-full rounded-md border border-[#ccc] bg-white pl-3 pr-[54px] text-[15px] shadow-xs outline-none transition-[color,box-shadow] focus:border-cog-teal focus:ring-[3px] focus:ring-cog-teal/30 disabled:cursor-not-allowed disabled:opacity-60"
+          className="h-[42px] w-full rounded-md border border-[#ccc] bg-white pl-3 pr-[54px] text-base md:text-[15px] shadow-xs outline-none transition-[color,box-shadow] focus:border-cog-teal focus:ring-[3px] focus:ring-cog-teal/30 disabled:cursor-not-allowed disabled:opacity-60"
         />
         <button
           type="submit"
@@ -658,7 +658,7 @@ function SignupDialog({
   const labelCls = "mb-1.5 block text-sm font-bold"
   const inputCls = (invalid: boolean) =>
     cn(
-      "h-11 w-full rounded-md border bg-white px-3 text-[15px] shadow-xs outline-none transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-60",
+      "h-11 w-full rounded-md border bg-white px-3 text-base md:text-[15px] shadow-xs outline-none transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-60",
       invalid
         ? "border-destructive focus:border-destructive focus:ring-[3px] focus:ring-destructive/30"
         : "border-[#ccc] focus:border-cog-teal focus:ring-[3px] focus:ring-cog-teal/30",

--- a/web/apps/checkout/src/components/checkout/person-card.tsx
+++ b/web/apps/checkout/src/components/checkout/person-card.tsx
@@ -69,8 +69,10 @@ function showError(
   return null
 }
 
+// 16px on mobile: iOS Safari auto-zooms (and stays zoomed) when a focused
+// control's font-size is below 16px. See issue #492.
 const BASE_INPUT =
-  "flex h-9 w-full rounded-none border bg-background px-3 py-1 text-sm outline-none"
+  "flex h-9 w-full rounded-none border bg-background px-3 py-1 text-base md:text-sm outline-none"
 const INPUT_OK = `${BASE_INPUT} border-[#ccc] focus:border-cog-teal`
 const INPUT_ERR = `${BASE_INPUT} border-[#cc2a24] focus:border-[#cc2a24]`
 

--- a/web/apps/checkout/src/components/checkout/step-checkout.tsx
+++ b/web/apps/checkout/src/components/checkout/step-checkout.tsx
@@ -664,7 +664,7 @@ export function StepCheckout({
             id="usage-type"
             value={usageType}
             onChange={(e) => setUsageType(e.target.value as UsageType)}
-            className="mt-1.5 mb-4 h-10 w-full max-w-xs rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:border-cog-teal focus:ring-2 focus:ring-cog-teal/30"
+            className="mt-1.5 mb-4 h-10 w-full max-w-xs rounded-md border border-border bg-background px-3 text-base md:text-sm focus:outline-none focus:border-cog-teal focus:ring-2 focus:ring-cog-teal/30"
           >
             {Object.entries(USAGE_TYPE_LABELS).map(([key, label]) => (
               <option key={key} value={key}>
@@ -1075,7 +1075,7 @@ export function SpendeCard({
             value={String(roundUpTarget)}
             onChange={(e) => onRoundUpTarget(parseFloat(e.target.value))}
             aria-label="Aufrunden-Ziel"
-            className="appearance-none bg-transparent border-0 border-b border-dashed border-oww-gold-dark/70 text-oww-gold-text font-semibold pr-5 pl-1 py-0.5 cursor-pointer focus:outline-none focus:border-oww-gold-dark"
+            className="appearance-none bg-transparent border-0 border-b border-dashed border-oww-gold-dark/70 text-base md:text-sm text-oww-gold-text font-semibold pr-5 pl-1 py-0.5 cursor-pointer focus:outline-none focus:border-oww-gold-dark"
             style={{
               backgroundImage:
                 "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23a07c00' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>\")",

--- a/web/apps/checkout/src/components/usage/inline-rows.tsx
+++ b/web/apps/checkout/src/components/usage/inline-rows.tsx
@@ -642,7 +642,7 @@ function PinnedValueField({
           onChange(raw)
         }}
         onBlur={onBlur}
-        className="h-8 w-16 rounded-[3px] border border-[#ccc] bg-background px-2 text-right text-sm tabular-nums text-foreground outline-none focus:border-cog-teal"
+        className="h-8 w-16 rounded-[3px] border border-[#ccc] bg-background px-2 text-right text-base md:text-sm tabular-nums text-foreground outline-none focus:border-cog-teal"
       />
       <span className="text-xs text-muted-foreground">{suffix}</span>
     </span>

--- a/web/apps/checkout/src/components/usage/material-picker.tsx
+++ b/web/apps/checkout/src/components/usage/material-picker.tsx
@@ -38,8 +38,10 @@ import {
   reassertPageScroll,
 } from "./picker-scroll-anchor"
 
+// 16px on mobile: iOS Safari auto-zooms (and stays zoomed) when a focused
+// control's font-size is below 16px. See issue #492.
 const INPUT_CLS =
-  "flex h-9 w-full rounded-none border border-[#ccc] bg-background px-3 py-1 text-sm outline-none focus:border-cog-teal"
+  "flex h-9 w-full rounded-none border border-[#ccc] bg-background px-3 py-1 text-base md:text-sm outline-none focus:border-cog-teal"
 
 // Fallback pricing models surfaced when the search has no catalog match.
 // Lets the member add ad-hoc materials we don't track in the catalog yet —
@@ -257,7 +259,7 @@ function PickerHeader({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Material suchen…"
-            className="flex-1 bg-transparent text-sm outline-none"
+            className="flex-1 bg-transparent text-base md:text-sm outline-none"
             aria-label="Material suchen"
           />
           {query && (

--- a/web/apps/checkout/src/routes/_authenticated/account/profile.tsx
+++ b/web/apps/checkout/src/routes/_authenticated/account/profile.tsx
@@ -43,14 +43,16 @@ interface ProfileFormValues {
   phone: string
 }
 
+// 16px on mobile: iOS Safari auto-zooms (and stays zoomed) when a focused
+// control's font-size is below 16px. See issue #492.
 const INPUT_BASE =
-  "block w-full h-10 rounded-md border bg-background px-3 text-sm shadow-xs outline-none transition-colors"
+  "block w-full h-10 rounded-md border bg-background px-3 text-base md:text-sm shadow-xs outline-none transition-colors"
 const INPUT =
   `${INPUT_BASE} border-[#ccc] focus:border-cog-teal focus:ring-2 focus:ring-cog-teal/30`
 const INPUT_ERR =
   `${INPUT_BASE} border-destructive focus:border-destructive focus:ring-2 focus:ring-destructive/30`
 const INPUT_DISABLED =
-  "block w-full h-10 rounded-md border border-[#ccc] bg-muted/50 px-3 text-sm text-muted-foreground cursor-not-allowed shadow-xs"
+  "block w-full h-10 rounded-md border border-[#ccc] bg-muted/50 px-3 text-base md:text-sm text-muted-foreground cursor-not-allowed shadow-xs"
 
 function ErrorText({ message }: { message?: string }) {
   if (!message) return null

--- a/web/modules/components/profile-form.tsx
+++ b/web/modules/components/profile-form.tsx
@@ -14,8 +14,10 @@ import { Label } from "@modules/components/ui/label"
 import { MapPin } from "lucide-react"
 import type { AddressValue, AddressErrors } from "@modules/lib/address"
 
+// 16px on mobile: iOS Safari auto-zooms (and stays zoomed) when a focused
+// control's font-size is below 16px. See issue #492.
 const INPUT_BASE =
-  "block w-full h-10 rounded-md border bg-background px-3 text-sm shadow-xs outline-none transition-colors"
+  "block w-full h-10 rounded-md border bg-background px-3 text-base md:text-sm shadow-xs outline-none transition-colors"
 export const INPUT_OK = `${INPUT_BASE} border-[#ccc] focus:border-cog-teal focus:ring-2 focus:ring-cog-teal/30`
 export const INPUT_ERR = `${INPUT_BASE} border-destructive focus:border-destructive focus:ring-2 focus:ring-destructive/30`
 

--- a/web/modules/components/ui/input-otp.tsx
+++ b/web/modules/components/ui/input-otp.tsx
@@ -15,7 +15,12 @@ function InputOTP({
     <OTPInput
       data-slot="input-otp"
       containerClassName={cn(
-        "flex items-center gap-2 has-disabled:opacity-50",
+        // text-base: the library's hidden <input> uses font-size:
+        // var(--root-height), which is only set after mount (ResizeObserver).
+        // With autoFocus, iOS Safari evaluates the font-size before that and
+        // falls back to the inherited size — keep it >= 16px so iOS doesn't
+        // auto-zoom the page (issue #492).
+        "flex items-center gap-2 text-base has-disabled:opacity-50",
         containerClassName
       )}
       className={cn("disabled:cursor-not-allowed", className)}


### PR DESCRIPTION
Fixes #492

## Root cause

iOS Safari auto-zooms the page when a focused form control's computed font-size is below 16px — and the zoom **persists after blur**. In the SPA it then survives navigation, so the whole app rendered cropped/"zu breit" on every page. The Marker.io metadata in #492 confirms it: screen 393pt but visual viewport 344px ⇒ zoom factor 393/344 ≈ 16/14, the exact signature of a focused 14px (`text-sm`) control. (An over-wide layout element would have produced a *wider* viewport, not a narrower one.)

## Fix

Apply the `text-base md:text-sm` pattern (already the convention in the shadcn `Input`/`Textarea` primitives) to every focusable control that rendered below 16px on mobile — 16px under the `md` breakpoint, unchanged desktop look:

- `material-picker.tsx` — shared `INPUT_CLS` (all quantity/dimension inputs, several `autoFocus`) + the `autoFocus` search field on the reported page
- `inline-rows.tsx` — pinned-quantity input
- `step-checkout.tsx` — Nutzungsart select + round-up select (inherited 14px from its wrapper)
- `checkin-signin.tsx` — both 15px email inputs (`text-base md:text-[15px]`)
- `person-card.tsx`, `profile.tsx`, shared `profile-form.tsx` `INPUT_BASE` (covers login-page, signup-fields, invite page)
- `ui/input-otp.tsx` — `text-base` on the OTP container: the input-otp library sizes its hidden real `<input>` via `font-size: var(--root-height)`, which is only set post-mount (ResizeObserver), while `autoFocus` fires during React commit — so iOS reads the *inherited* size at focus time

## Regression guard

New `e2e/ios-input-zoom.spec.ts`: at the mobile viewport it walks every rendered `input`/`select`/`textarea` on the sign-in surfaces (login, check-in email, OTP dialog) and in the material picker (search + quantity form) and fails if any computes below 16px — the deterministic trigger condition behind the iOS behavior. Mutation-tested: reverting `INPUT_CLS` to `text-sm` makes it fail.

## Testing

- Full precommit suite green (web build, 744 + 59 unit, 152 integration tests)
- Checkout e2e: 189 passed (the one failing screenshot test, ad-hoc-item mobile, fails identically on clean `main` locally — pre-existing scroll-race flake, unrelated); admin e2e: 27 passed
- **Verified on real iOS Safari via staging** — the zoom no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGN9ToWJrjyThHfqfJKwHy