### PR TITLE
test: pin ad-hoc screenshot scroll until it sticks (fixes red main)

### DIFF
--- a/web/apps/checkout/e2e/checkout-screenshots.spec.ts
+++ b/web/apps/checkout/e2e/checkout-screenshots.spec.ts
@@ -250,12 +250,23 @@ test.describe("Checkout step screenshots", () => {
     await page.getByRole("button", { name: "Schliessen" }).click()
     await expect(page.locator(`[data-slot="sheet-overlay"]`)).toBeHidden()
 
-    // Let issue #401's post-close scroll-restore rAF window (~600ms) settle,
-    // then pin to the top so the baseline is deterministic (same idiom as
-    // the "add article dropdown open" test — the picker flow otherwise
-    // leaves the page at a race-dependent scroll offset on mobile).
-    await page.waitForTimeout(700)
-    await page.evaluate(() => window.scrollTo(0, 0))
+    // Pin the page to the top and keep re-pinning until it sticks. The
+    // close-path scroll restore (#451) re-applies the pre-open offset (here:
+    // scrolled down to the holz add button) on an rAF schedule whose end we
+    // can't observe — a single pin after a fixed settle loses that race on
+    // slow runners, which left this baseline permanently red on CI. Each
+    // poll iteration pins, out-waits the ~600ms restore window, and only
+    // passes once the pin survived it.
+    await expect
+      .poll(
+        async () => {
+          await page.evaluate(() => window.scrollTo(0, 0))
+          await page.waitForTimeout(700)
+          return page.evaluate(() => window.scrollY)
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(0)
 
     await expect(page).toHaveScreenshot("checkout-materials-added.png")
   })


### PR DESCRIPTION
Main's e2e leg (checkout 3/4) has been red since 2026-07-17: `checkout-screenshots.spec.ts › materials added with ad-hoc item` fails on mobile-chrome with a deterministic 19,098-pixel diff — including on the baseline-heal commit (2f483617) itself.

## Root cause

The test opens the third picker sheet from a scrolled-down position, closes it, waits a fixed 700ms for the #451 close-path scroll restore, then pins `scrollTo(0, 0)` and screenshots. The restore re-applies the pre-open offset on an rAF schedule whose end the test can't observe — on current runners it lands **after** the 700ms window, re-scrolling the page ~135px past the pin. The capture then shows the scrolled state while the (correctly top-anchored) baseline shows the top. That's why regenerating the baseline didn't stick: the baseline was fine, the pin was losing the race.

## Fix

Replace the single fixed-delay pin with an `expect.poll` loop: each iteration pins to the top, out-waits the restore window, and only proceeds once the pin survived it. No baseline change needed.

## Verification

The failure reproduced 1:1 locally on clean main (same 19,098-pixel diff as CI). With this change: chromium + mobile-chrome pass, plus repeated mobile runs (`--repeat-each=2`) — all green.

Unblocks #573, which currently inherits this failure in its presubmit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGN9ToWJrjyThHfqfJKwHy