### PR TITLE
chore(kiosk): env-specific installer names + bump to 1.0.4

### DIFF
--- a/checkout-kiosk/README.md
+++ b/checkout-kiosk/README.md
@@ -46,8 +46,12 @@ for the full env-var list.
 ## Packaging
 
 ```bash
-npm run build:kiosk     # → release/kiosk/oww-kiosk-<ver>-setup.exe (et al.)
+npm run build:kiosk     # → release/kiosk/oww-kiosk-dev-<ver>-setup.exe (et al.)
 ```
+
+Installer names carry the environment (`dev` / `staging` / `prod`, via the
+`KIOSK_DIST` env var each npm script sets) so builds for different
+environments never overwrite each other.
 
 electron-builder config: `electron-builder.kiosk.yml`.
 
@@ -83,16 +87,18 @@ threat model.
 
 Bump the `version` field in `checkout-kiosk/package.json` **once per change you
 ship** (semver — `1.0.1`, `1.0.2`, …). That single field is the source of truth:
-electron-builder names the installer `oww-kiosk-<version>-setup.exe`, stamps the
-NSIS product version, and it's what `app.getVersion()` returns (shown in the
-tray/taskbar tooltip). Forget to bump it and every build overwrites the same
-`oww-kiosk-1.0.0-setup.exe` — impossible to tell apart. Delete stale
-`release/kiosk/oww-kiosk-*-setup.exe` from older versions when they pile up.
+electron-builder names the installer `oww-kiosk-<env>-<version>-setup.exe`,
+stamps the NSIS product version, and it's what `app.getVersion()` returns
+(shown in the tray/taskbar tooltip). Forget to bump it and every build of the
+same environment overwrites the same installer — impossible to tell apart.
+Delete stale `release/kiosk/oww-kiosk-*-setup.exe` from older versions when
+they pile up.
 
 ### Production builds (`--prod`)
 
 ```bash
-npm run build:kiosk:prod    # → release/kiosk/oww-kiosk-<ver>-setup.exe
+npm run build:kiosk:prod       # → release/kiosk/oww-kiosk-prod-<ver>-setup.exe
+npm run build:kiosk:staging    # → release/kiosk/oww-kiosk-staging-<ver>-setup.exe
 ```
 
 The `:prod` script always targets a **Windows x64 NSIS installer**

--- a/checkout-kiosk/electron-builder.kiosk.yml
+++ b/checkout-kiosk/electron-builder.kiosk.yml
@@ -21,7 +21,9 @@ win:
   target:
     - target: nsis
       arch: x64
-  artifactName: oww-kiosk-${version}-setup.${ext}
+  # KIOSK_DIST is set by the build:kiosk* npm scripts (dev/staging/prod)
+  # so installers from different environments can't overwrite each other.
+  artifactName: oww-kiosk-${env.KIOSK_DIST}-${version}-setup.${ext}
 nsis:
   oneClick: false
   perMachine: false
@@ -29,7 +31,7 @@ nsis:
 linux:
   target:
     - AppImage
-  artifactName: oww-kiosk-${version}-${arch}.${ext}
+  artifactName: oww-kiosk-${env.KIOSK_DIST}-${version}-${arch}.${ext}
 mac:
   target: dmg
-  artifactName: oww-kiosk-${version}-${arch}.${ext}
+  artifactName: oww-kiosk-${env.KIOSK_DIST}-${version}-${arch}.${ext}

--- a/checkout-kiosk/package.json
+++ b/checkout-kiosk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-kiosk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Electron hardware bridge for the OWW checkout kiosk (NFC).",
   "main": "dist/main.js",
   "scripts": {
@@ -11,9 +11,9 @@
     "start:kiosk": "npm run _compile && electron .",
     "dev:kiosk": "npm run start:kiosk",
     "start:kiosk:staging": "node scripts/inject-build-config.mjs --env staging && npm run tsc:main && npm run tsc:renderer && electron .",
-    "build:kiosk": "npm run _compile && electron-builder --config electron-builder.kiosk.yml",
-    "build:kiosk:staging": "node scripts/inject-build-config.mjs --env staging && npm run tsc:main && npm run tsc:renderer && electron-builder --config electron-builder.kiosk.yml --win",
-    "build:kiosk:prod": "node scripts/inject-build-config.mjs --prod && npm run tsc:main && npm run tsc:renderer && electron-builder --config electron-builder.kiosk.yml --win",
+    "build:kiosk": "npm run _compile && cross-env KIOSK_DIST=dev electron-builder --config electron-builder.kiosk.yml",
+    "build:kiosk:staging": "node scripts/inject-build-config.mjs --env staging && npm run tsc:main && npm run tsc:renderer && cross-env KIOSK_DIST=staging electron-builder --config electron-builder.kiosk.yml --win",
+    "build:kiosk:prod": "node scripts/inject-build-config.mjs --prod && npm run tsc:main && npm run tsc:renderer && cross-env KIOSK_DIST=prod electron-builder --config electron-builder.kiosk.yml --win",
     "test": "npm run inject-build-config && tsx --test \"src/**/*.test.ts\"",
     "rebuild": "electron-rebuild",
     "postinstall": "electron-rebuild",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       }
     },
     "checkout-kiosk": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "hasInstallScript": true,
       "dependencies": {
         "@oww/shared": "*",


### PR DESCRIPTION
## Summary

- Bump kiosk to **1.0.4**.
- The prod and staging build profiles both emitted `oww-kiosk-<version>-setup.exe`, so building one environment silently overwrote the other's installer. The `build:kiosk*` npm scripts now set `KIOSK_DIST` (`dev`/`staging`/`prod` via cross-env) and the electron-builder artifact names include it: `oww-kiosk-prod-1.0.4-setup.exe` / `oww-kiosk-staging-1.0.4-setup.exe`.
- README updated to document the naming scheme.

## Verification

Both installers were built from this change and the staging one validated end to end (short of a physical tag tap):

- Staging bake resolved via the ADR-0034 overlay to `https://oww-maco-staging.web.app/?kiosk`; the packaged `app.asar` contains only the staging URL (no prod URL).
- `KIOSK_BEARER_KEY` in `oww-maco-staging` matches the prod Secret Manager value, so the baked bearer is accepted by staging functions.
- Staging checkout hosting serves (HTTP 200) and the staging `authCall` dispatcher is deployed.
- Smoke-launched the packaged staging build: window opens, NFC init failure without a reader is handled, clean shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)