### PR TITLE
Personalize firmware: verify already-personalized tags

### DIFF
--- a/docs/adr/0017-ntag424-sdm-self-checkout.md
+++ b/docs/adr/0017-ntag424-sdm-self-checkout.md
@@ -74,7 +74,7 @@ ChangeFileSettings payload (15 bytes):
 5. Enable SDM via ChangeFileSettings
 6. Verify via GetFileSettings
 
-Steps 4-6 are idempotent: `IsSdmConfigured()` compares the full GetFileSettings response against expected values, so if the configuration changes in a future firmware update, re-personalizing will detect the mismatch and reconfigure.
+Steps 4-6 are idempotent: `IsSdmConfigured()` compares the full GetFileSettings response against expected values. This flow only runs for **factory** tags. Tags that already authenticate with the terminal key (MaCo tags) are routed to a read-only **verification** flow instead (`personalization_verifier.cc`): all 5 key slots are checked by mutual authentication with the expected keys, plus random-UID, real UID, NDEF template, and SDM file settings. A MaCo tag that fails verification (e.g. after an SDM layout change in a future firmware) is reported with the failing checks but is *not* automatically reconfigured — re-personalization of live tags is a deliberate, separate operator action, not a side effect of a tap.
 
 ### Backend Verification
 

--- a/maco_firmware/apps/personalize/BUILD.bazel
+++ b/maco_firmware/apps/personalize/BUILD.bazel
@@ -107,6 +107,26 @@ cc_library(
     ],
 )
 
+# Personalization verifier - checks keys + configuration of a MaCo tag
+cc_library(
+    name = "personalization_verifier",
+    srcs = ["personalization_verifier.cc"],
+    hdrs = ["personalization_verifier.h"],
+    deps = [
+        ":personalization_keys",
+        ":sdm_constants",
+        "//maco_firmware/modules/nfc_tag/ntag424:local_key_provider",
+        "//maco_firmware/modules/nfc_tag/ntag424:ntag424_session",
+        "//maco_firmware/modules/nfc_tag/ntag424:ntag424_tag",
+        "@pigweed//pw_async2:coro",
+        "@pigweed//pw_bytes",
+        "@pigweed//pw_log",
+        "@pigweed//pw_random",
+        "@pigweed//pw_result",
+        "@pigweed//pw_string",
+    ],
+)
+
 # Personalization coordinator - orchestrates identification, keys, and SDM
 cc_library(
     name = "personalize_coordinator",
@@ -114,6 +134,7 @@ cc_library(
     hdrs = ["personalize_coordinator.h"],
     deps = [
         ":key_updater",
+        ":personalization_verifier",
         ":personalization_keys",
         ":screens",
         ":sdm_configurator",

--- a/maco_firmware/apps/personalize/personalization_rpc_service.cc
+++ b/maco_firmware/apps/personalize/personalization_rpc_service.cc
@@ -58,8 +58,26 @@ pw::Status PersonalizationRpcService::GetPersonalizeState(
       response.state =
           P::maco_GetPersonalizeStateResponse_State_PERSONALIZED;
       break;
+    case S::kVerifying:
+      response.state = P::maco_GetPersonalizeStateResponse_State_VERIFYING;
+      break;
+    case S::kVerified:
+      response.state = P::maco_GetPersonalizeStateResponse_State_VERIFIED;
+      break;
     case S::kError:
       response.state = P::maco_GetPersonalizeStateResponse_State_ERROR;
+      break;
+  }
+
+  switch (snapshot.tag_kind) {
+    case DetectedTagKind::kNone:
+      response.tag_type = maco_TagEvent_TagType_TAG_UNKNOWN;
+      break;
+    case DetectedTagKind::kFactory:
+      response.tag_type = maco_TagEvent_TagType_TAG_FACTORY;
+      break;
+    case DetectedTagKind::kMaco:
+      response.tag_type = maco_TagEvent_TagType_TAG_MACO;
       break;
   }
 

--- a/maco_firmware/apps/personalize/personalization_verifier.cc
+++ b/maco_firmware/apps/personalize/personalization_verifier.cc
@@ -1,0 +1,222 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+#define PW_LOG_MODULE_NAME "VERIFY"
+
+#include "maco_firmware/apps/personalize/personalization_verifier.h"
+
+#include <algorithm>
+#include <optional>
+
+#include "maco_firmware/apps/personalize/sdm_constants.h"
+#include "maco_firmware/modules/nfc_tag/ntag424/local_key_provider.h"
+#include "pw_log/log.h"
+
+namespace maco::personalize {
+
+namespace {
+
+// ISO 14443-3: a random ID is single-size (4 bytes) with UID0 = 0x08. Real
+// NTAG UIDs are 7 bytes starting with 0x04 (NXP). There is no readback for
+// the PICC configuration, so the anticollision UID shape is the definitive
+// check that Random ID is enabled.
+constexpr size_t kRandomIdLength = 4;
+constexpr std::byte kRandomIdFirstByte{0x08};
+
+struct KeyCheck {
+  uint8_t number;
+  const char* name;
+  pw::ConstByteSpan key;
+};
+
+void LogHex(const char* label, pw::ConstByteSpan data) {
+  pw::StringBuffer<2 * sdm::kMaxNdefSize + 1> hex;
+  for (std::byte b : data) {
+    hex.Format("%02x", static_cast<unsigned>(b));
+  }
+  PW_LOG_WARN("%s: %s", label, hex.c_str());
+}
+
+}  // namespace
+
+bool VerificationReport::AllOk() const {
+  if (!random_uid_enabled || !read_checks_ran || !uid_matches ||
+      !ndef_matches || !sdm_settings_ok) {
+    return false;
+  }
+  return std::all_of(key_ok.begin(), key_ok.end(), [](bool ok) { return ok; });
+}
+
+void VerificationReport::FormatFailures(pw::StringBuilder& out) const {
+  bool first = true;
+  auto add = [&](const char* label) {
+    if (!first) {
+      out << ", ";
+    }
+    out << label;
+    first = false;
+  };
+
+  if (!random_uid_enabled) {
+    add("RandomUID");
+  }
+  static constexpr const char* kKeyLabels[kNumKeys] = {
+      "Key0", "Key1", "Key2", "Key3", "Key4"};
+  for (size_t i = 0; i < kNumKeys; ++i) {
+    if (!key_ok[i]) {
+      add(kKeyLabels[i]);
+    }
+  }
+  if (!read_checks_ran) {
+    add("Lese-Checks (kein Key0)");
+    return;
+  }
+  if (!uid_matches) {
+    add("UID");
+  }
+  if (!ndef_matches) {
+    add("NDEF");
+  }
+  if (!sdm_settings_ok) {
+    add("SDM");
+  }
+}
+
+pw::async2::Coro<pw::Result<VerificationReport>> VerifyPersonalization(
+    pw::async2::CoroContext cx,
+    nfc::Ntag424Tag& ntag,
+    pw::ConstByteSpan anticollision_uid,
+    pw::ConstByteSpan expected_uid,
+    const PersonalizationKeys& keys,
+    pw::random::RandomGenerator& rng) {
+  VerificationReport report;
+
+  report.random_uid_enabled =
+      anticollision_uid.size() == kRandomIdLength &&
+      anticollision_uid[0] == kRandomIdFirstByte;
+  if (!report.random_uid_enabled) {
+    PW_LOG_WARN("Random UID not enabled (%u-byte anticollision UID)",
+                static_cast<unsigned>(anticollision_uid.size()));
+  }
+
+  // Slot 0 last: its session is reused for the read checks below.
+  const KeyCheck checks[] = {
+      {1, "terminal", keys.terminal_key},
+      {2, "authorization", keys.authorization_key},
+      {3, "sdm_mac", keys.sdm_mac_key},
+      {4, "reserved2", keys.reserved2_key},
+      {0, "application", keys.application_key},
+  };
+
+  std::optional<nfc::Ntag424Session> session;
+  for (const auto& check : checks) {
+    // Re-select before every attempt: a failed AuthenticateEV2First clears
+    // the tag's authentication state, so start each slot from scratch.
+    auto select_status = co_await ntag.SelectApplication(cx);
+    if (!select_status.ok()) {
+      PW_LOG_ERROR("SelectApplication failed during verification: %d",
+                   static_cast<int>(select_status.code()));
+      co_return select_status;
+    }
+
+    nfc::LocalKeyProvider key_provider(check.number, check.key, rng);
+    auto auth_result = co_await ntag.Authenticate(cx, key_provider);
+    report.key_ok[check.number] = auth_result.ok();
+    if (auth_result.ok()) {
+      PW_LOG_INFO("Key %u (%s) verified",
+                  static_cast<unsigned>(check.number), check.name);
+      if (check.number == 0) {
+        session = *auth_result;
+      }
+    } else {
+      PW_LOG_WARN("Key %u (%s) MISMATCH: auth failed: %d",
+                  static_cast<unsigned>(check.number), check.name,
+                  static_cast<int>(auth_result.status().code()));
+    }
+  }
+
+  if (!session.has_value()) {
+    PW_LOG_WARN("Key 0 not verified — skipping UID/NDEF/SDM checks");
+    co_return report;
+  }
+  report.read_checks_ran = true;
+
+  // Real UID via GetCardUid (works regardless of Random ID).
+  std::array<std::byte, 7> uid_buffer{};
+  auto uid_result =
+      co_await ntag.GetCardUid(cx, *session, pw::ByteSpan(uid_buffer));
+  report.uid_matches =
+      uid_result.ok() && *uid_result == expected_uid.size() &&
+      std::equal(expected_uid.begin(), expected_uid.end(), uid_buffer.begin());
+  if (!report.uid_matches) {
+    PW_LOG_WARN("UID mismatch or GetCardUid failed");
+  }
+
+  auto template_result = sdm::BuildNdefTemplate(keys.sdm_base_url);
+  if (!template_result.ok()) {
+    PW_LOG_ERROR("Cannot build NDEF template for verification");
+    co_return report;
+  }
+  const auto& ndef = *template_result;
+
+  // File settings before the NDEF read: the NDEF file's read access is
+  // free (Eh), so its plain-mode ReadData is served outside the secure
+  // session. Keeping all MACed session commands ahead of it removes any
+  // dependency on counter behavior across that boundary.
+  std::array<std::byte, 32> settings_buffer{};
+  auto settings_result = co_await ntag.GetFileSettings(
+      cx, *session, sdm::kNdefFileNumber, settings_buffer);
+  if (!settings_result.ok()) {
+    PW_LOG_WARN("GetFileSettings failed: %d",
+                static_cast<int>(settings_result.status().code()));
+  } else {
+    pw::ConstByteSpan settings(settings_buffer.data(), *settings_result);
+    report.sdm_settings_ok = sdm::IsSdmConfigured(
+        settings, ndef.picc_data_offset, ndef.sdm_mac_offset);
+    if (!report.sdm_settings_ok) {
+      LogHex("SDM settings on tag", settings);
+      LogHex("SDM settings expected (ChangeFileSettings payload)",
+             sdm::BuildSdmFileSettings(ndef.picc_data_offset,
+                                       ndef.sdm_mac_offset));
+    }
+  }
+
+  // Read back the NDEF file. Read access is free, so this read goes
+  // through the same SDM path as a phone tap: the mirror regions come
+  // back with live PICC data/CMAC (excluded from the compare) and each
+  // chunk consumes one SDMReadCtr value — the counter cost of verifying.
+  // Kept last: see the GetFileSettings ordering comment above.
+  std::array<std::byte, sdm::kMaxNdefSize> read_buffer{};
+  bool read_ok = true;
+  size_t offset = 0;
+  while (offset < ndef.size) {
+    size_t chunk = std::min(sdm::kReadChunkSize, ndef.size - offset);
+    auto read_result = co_await ntag.ReadData(
+        cx, *session, sdm::kNdefFileNumber, offset, chunk,
+        pw::ByteSpan(read_buffer.data() + offset, chunk),
+        nfc::CommMode::kPlain);
+    if (!read_result.ok() || *read_result != chunk) {
+      PW_LOG_WARN("NDEF read at offset %u failed: %d (%u bytes)",
+                  static_cast<unsigned>(offset),
+                  static_cast<int>(read_result.status().code()),
+                  read_result.ok() ? static_cast<unsigned>(*read_result) : 0u);
+      read_ok = false;
+      break;
+    }
+    offset += chunk;
+  }
+  report.ndef_matches =
+      read_ok && sdm::NdefContentMatches(
+                     pw::ConstByteSpan(read_buffer.data(), ndef.size), ndef);
+  if (!report.ndef_matches) {
+    PW_LOG_WARN("NDEF content mismatch");
+    if (read_ok) {
+      LogHex("NDEF on tag", pw::ConstByteSpan(read_buffer.data(), ndef.size));
+      LogHex("NDEF expected", ndef.content());
+    }
+  }
+
+  co_return report;
+}
+
+}  // namespace maco::personalize

--- a/maco_firmware/apps/personalize/personalization_verifier.h
+++ b/maco_firmware/apps/personalize/personalization_verifier.h
@@ -1,0 +1,72 @@
+// Copyright Offene Werkstatt Wädenswil
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "maco_firmware/apps/personalize/personalization_keys.h"
+#include "maco_firmware/modules/nfc_tag/ntag424/ntag424_tag.h"
+#include "pw_async2/coro.h"
+#include "pw_bytes/span.h"
+#include "pw_random/random.h"
+#include "pw_result/result.h"
+#include "pw_string/string_builder.h"
+
+namespace maco::personalize {
+
+/// Outcome of verifying an already-personalized (MaCo) tag against the
+/// expected keys and SDM configuration.
+struct VerificationReport {
+  static constexpr size_t kNumKeys = 5;
+
+  /// Anticollision UID is a 4-byte random ID (first byte 0x08).
+  bool random_uid_enabled = false;
+
+  /// Per key slot: AuthenticateEV2First with the expected key succeeded.
+  /// Mutual authentication is the only way to check a key — success proves
+  /// the slot holds exactly the expected key.
+  std::array<bool, kNumKeys> key_ok{};
+
+  /// GetCardUid returned the expected real 7-byte UID.
+  bool uid_matches = false;
+
+  /// NDEF file content matches the template (outside the SDM mirrors).
+  bool ndef_matches = false;
+
+  /// GetFileSettings shows SDM enabled with the expected options/offsets.
+  bool sdm_settings_ok = false;
+
+  /// False when key 0 did not authenticate, so the checks that need an
+  /// authenticated session (UID, NDEF, file settings) could not run.
+  bool read_checks_ran = false;
+
+  bool AllOk() const;
+
+  /// Append a compact comma-separated list of the failed checks.
+  void FormatFailures(pw::StringBuilder& out) const;
+};
+
+/// Verify a personalized tag against the keys delivered over RPC.
+///
+/// Authenticates every key slot with its expected key (slots 1-4 first,
+/// slot 0 last so its session is reused for the session-bound checks:
+/// GetCardUid and GetFileSettings), then verifies the real UID, the SDM
+/// file settings, and the NDEF template. The NDEF file's read access is
+/// free, so its read-back is served via the SDM path like a phone tap:
+/// mirror regions are excluded from the compare and each verification
+/// consumes SDMReadCtr values (one per read chunk).
+///
+/// Key mismatches and configuration deviations are recorded in the
+/// report; only transport-level failures (tag left the field) return an
+/// error status.
+pw::async2::Coro<pw::Result<VerificationReport>> VerifyPersonalization(
+    pw::async2::CoroContext cx,
+    nfc::Ntag424Tag& ntag,
+    pw::ConstByteSpan anticollision_uid,
+    pw::ConstByteSpan expected_uid,
+    const PersonalizationKeys& keys,
+    pw::random::RandomGenerator& rng);
+
+}  // namespace maco::personalize

--- a/maco_firmware/apps/personalize/personalize_coordinator.cc
+++ b/maco_firmware/apps/personalize/personalize_coordinator.cc
@@ -6,14 +6,73 @@
 #include "maco_firmware/apps/personalize/personalize_coordinator.h"
 
 #include "maco_firmware/apps/personalize/key_updater.h"
+#include "maco_firmware/apps/personalize/personalization_verifier.h"
 #include "maco_firmware/apps/personalize/sdm_configurator.h"
 #include "maco_firmware/apps/personalize/tag_identifier.h"  // TagInfoFromNfcTag
 #include "maco_firmware/modules/nfc_reader/nfc_event.h"
 #include "maco_firmware/modules/nfc_tag/ntag424/local_key_provider.h"
 #include "maco_firmware/modules/nfc_tag/ntag424/ntag424_tag.h"
+#include "pw_async2/future.h"
 #include "pw_log/log.h"
 
 namespace maco::personalize {
+
+namespace {
+
+/// Races console key delivery against the next NFC event so that a tag
+/// leaving the field aborts the wait — otherwise the coordinator would sit
+/// in "awaiting keys" forever and ignore every subsequent tap.
+///
+/// Modeled on async_util::ValueOrTimeout (see its header for why pw_async2's
+/// own combinator headers are avoided). The losing future is dropped
+/// unresolved, which is safe for ValueFuture: its destructor unlists itself
+/// from the provider, and a later Resolve with no waiter is a no-op.
+class [[nodiscard]] KeysOrNfcEvent {
+ public:
+  struct Outcome {
+    std::optional<PersonalizationKeys> keys;
+    std::optional<nfc::NfcEvent> event;
+  };
+  using value_type = Outcome;
+
+  constexpr KeysOrNfcEvent() = default;
+
+  KeysOrNfcEvent(pw::async2::ValueFuture<PersonalizationKeys>&& keys,
+                 nfc::EventFuture&& event)
+      : keys_(std::move(keys)),
+        event_(std::move(event)),
+        state_(pw::async2::FutureState::kPending) {}
+
+  [[nodiscard]] constexpr bool is_pendable() const {
+    return state_.is_pendable();
+  }
+  [[nodiscard]] constexpr bool is_complete() const {
+    return state_.is_complete();
+  }
+
+  pw::async2::Poll<Outcome> Pend(pw::async2::Context& cx) {
+    auto keys = keys_.Pend(cx);
+    if (keys.IsReady()) {
+      state_.MarkComplete();
+      return pw::async2::Ready(
+          Outcome{.keys = std::move(*keys), .event = std::nullopt});
+    }
+    auto event = event_.Pend(cx);
+    if (event.IsReady()) {
+      state_.MarkComplete();
+      return pw::async2::Ready(
+          Outcome{.keys = std::nullopt, .event = std::move(*event)});
+    }
+    return pw::async2::Pending();
+  }
+
+ private:
+  pw::async2::ValueFuture<PersonalizationKeys> keys_;
+  nfc::EventFuture event_;
+  pw::async2::FutureState state_;
+};
+
+}  // namespace
 
 PersonalizeCoordinator::PersonalizeCoordinator(
     nfc::NfcReader& reader,
@@ -53,14 +112,21 @@ void PersonalizeCoordinator::GetSnapshot(PersonalizeSnapshot& snapshot) {
 void PersonalizeCoordinator::SetState(PersonalizeStateId state) {
   std::lock_guard guard(lock_);
   snapshot_.state = state;
+  if (state == PersonalizeStateId::kIdle) {
+    // No tag in the field — drop the stale identification.
+    snapshot_.tag_kind = DetectedTagKind::kNone;
+    snapshot_.uid_size = 0;
+  }
 }
 
 void PersonalizeCoordinator::SetStateWithUid(
     PersonalizeStateId state,
+    DetectedTagKind tag_kind,
     const std::array<std::byte, 7>& uid,
     size_t uid_size) {
   std::lock_guard guard(lock_);
   snapshot_.state = state;
+  snapshot_.tag_kind = tag_kind;
   snapshot_.uid = uid;
   snapshot_.uid_size = uid_size;
 }
@@ -106,8 +172,15 @@ pw::async2::Coro<pw::Status> PersonalizeCoordinator::Run(
   while (true) {
     SetState(PersonalizeStateId::kIdle);
 
-    auto event_future = reader_.SubscribeOnce();
-    nfc::NfcEvent event = co_await event_future;
+    nfc::NfcEvent event;
+    if (pending_event_.has_value()) {
+      // A tag arrival consumed by the awaiting-keys race in HandleTag.
+      event = std::move(*pending_event_);
+      pending_event_.reset();
+    } else {
+      auto event_future = reader_.SubscribeOnce();
+      event = co_await event_future;
+    }
 
     switch (event.type) {
       case nfc::NfcEventType::kTagArrived: {
@@ -189,30 +262,48 @@ pw::async2::Coro<pw::Status> PersonalizeCoordinator::HandleTag(
   auto screen_state = ident.type == TagType::kFactory
                           ? PersonalizeStateId::kFactoryTag
                           : PersonalizeStateId::kMacoTag;
+  auto tag_kind = ident.type == TagType::kFactory ? DetectedTagKind::kFactory
+                                                  : DetectedTagKind::kMaco;
 
-  SetStateWithUid(screen_state, uid_buffer, uid_size);
+  SetStateWithUid(screen_state, tag_kind, uid_buffer, uid_size);
   StreamTagEvent(maco_TagEvent_EventType_TAG_ARRIVED,
                  stream_tag_type,
                  pw::ConstByteSpan(uid_buffer.data(), uid_size), "");
 
-  // Wait for keys from the console
+  // Wait for keys from the console, aborting if the tag leaves the field.
   SetState(PersonalizeStateId::kAwaitingTag);
   PW_LOG_INFO("Waiting for keys from console...");
 
-  auto keys_future = keys_provider_.Get();
-  PersonalizationKeys keys = co_await keys_future;
+  KeysOrNfcEvent::Outcome outcome = co_await KeysOrNfcEvent(
+      keys_provider_.Get(), reader_.SubscribeOnce());
 
-  PW_LOG_INFO("Keys received from console, personalizing...");
+  if (!outcome.keys.has_value()) {
+    if (outcome.event.has_value() &&
+        outcome.event->type == nfc::NfcEventType::kTagArrived) {
+      // Departure was missed; hand the fresh arrival back to the main loop
+      // so the new tap is processed immediately.
+      PW_LOG_INFO("New tag arrived while waiting for keys");
+      pending_event_ = std::move(*outcome.event);
+    } else {
+      PW_LOG_INFO("Tag departed while waiting for keys");
+      StreamTagEvent(maco_TagEvent_EventType_TAG_DEPARTED,
+                     stream_tag_type,
+                     pw::ConstByteSpan(uid_buffer.data(), uid_size), "");
+    }
+    co_return pw::OkStatus();
+  }
+  const PersonalizationKeys& keys = *outcome.keys;
 
-  if (uid_size == maco::TagUid::kSize) {
-    auto tag_uid = maco::TagUid::FromArray(uid_buffer);
-    co_await TryPersonalize(cx, tag, tag_uid, keys);
+  PW_LOG_INFO("Keys received from console");
+
+  // uid_size was already validated to be a full 7-byte UID above.
+  auto tag_uid = maco::TagUid::FromArray(uid_buffer);
+  if (ident.type == TagType::kMaCo) {
+    // Already personalized: verify everything is written correctly
+    // instead of re-personalizing.
+    co_await TryVerify(cx, tag, tag_uid, keys);
   } else {
-    SetError("Invalid UID size for personalization");
-    StreamTagEvent(maco_TagEvent_EventType_PERSONALIZATION_FAILED,
-                   stream_tag_type,
-                   pw::ConstByteSpan(uid_buffer.data(), uid_size),
-                   "Invalid UID size");
+    co_await TryPersonalize(cx, tag, tag_uid, keys);
   }
 
   co_return pw::OkStatus();
@@ -274,12 +365,54 @@ pw::async2::Coro<pw::Status> PersonalizeCoordinator::TryPersonalize(
   }
 
   PW_LOG_INFO("Tag personalization complete!");
-  SetStateWithUid(
-      PersonalizeStateId::kPersonalized, verified_uid, verified_uid_size);
+  SetStateWithUid(PersonalizeStateId::kPersonalized, DetectedTagKind::kMaco,
+                  verified_uid, verified_uid_size);
   StreamTagEvent(maco_TagEvent_EventType_PERSONALIZATION_COMPLETE,
                  maco_TagEvent_TagType_TAG_MACO,
                  pw::ConstByteSpan(verified_uid.data(), verified_uid_size),
                  "");
+  co_return pw::OkStatus();
+}
+
+pw::async2::Coro<pw::Status> PersonalizeCoordinator::TryVerify(
+    pw::async2::CoroContext cx,
+    nfc::NfcTag& tag,
+    const maco::TagUid& tag_uid,
+    const PersonalizationKeys& keys) {
+  SetState(PersonalizeStateId::kVerifying);
+  PW_LOG_INFO("Starting tag verification...");
+
+  auto tag_info = TagInfoFromNfcTag(tag);
+  nfc::Ntag424Tag ntag(reader_, tag_info);
+
+  auto report_result = co_await VerifyPersonalization(
+      cx, ntag, tag.uid(), tag_uid.bytes(), keys, rng_);
+  if (!report_result.ok()) {
+    SetError("Verifikation abgebrochen (Tag entfernt?)");
+    StreamTagEvent(maco_TagEvent_EventType_VERIFICATION_FAILED,
+                   maco_TagEvent_TagType_TAG_MACO,
+                   tag_uid.bytes(), "Verification aborted");
+    co_return report_result.status();
+  }
+
+  const VerificationReport& report = *report_result;
+  if (report.AllOk()) {
+    PW_LOG_INFO("Tag verification passed!");
+    SetStateWithUid(PersonalizeStateId::kVerified, DetectedTagKind::kMaco,
+                    tag_uid.array(), maco::TagUid::kSize);
+    StreamTagEvent(maco_TagEvent_EventType_VERIFICATION_COMPLETE,
+                   maco_TagEvent_TagType_TAG_MACO,
+                   tag_uid.bytes(), "");
+    co_return pw::OkStatus();
+  }
+
+  pw::StringBuffer<128> failures;
+  report.FormatFailures(failures);
+  PW_LOG_ERROR("Tag verification FAILED: %s", failures.c_str());
+  SetError(failures.view());
+  StreamTagEvent(maco_TagEvent_EventType_VERIFICATION_FAILED,
+                 maco_TagEvent_TagType_TAG_MACO,
+                 tag_uid.bytes(), failures.view());
   co_return pw::OkStatus();
 }
 

--- a/maco_firmware/apps/personalize/personalize_coordinator.h
+++ b/maco_firmware/apps/personalize/personalize_coordinator.h
@@ -7,6 +7,7 @@
 
 #include "maco_firmware/apps/personalize/personalization_keys.h"
 #include "maco_firmware/apps/personalize/screens/personalize_screen.h"
+#include "maco_firmware/modules/nfc_reader/nfc_event.h"
 #include "maco_firmware/modules/nfc_reader/nfc_reader.h"
 #include "maco_firmware/modules/nfc_tag/nfc_tag.h"
 #include "maco_firmware/modules/nfc_tag/ntag424/ntag424_tag.h"
@@ -64,8 +65,17 @@ class PersonalizeCoordinator {
       const maco::TagUid& tag_uid,
       const PersonalizationKeys& keys);
 
+  /// Verify an already-personalized tag against the delivered keys:
+  /// all key slots, random UID, real UID, NDEF template, SDM settings.
+  pw::async2::Coro<pw::Status> TryVerify(
+      pw::async2::CoroContext cx,
+      nfc::NfcTag& tag,
+      const maco::TagUid& tag_uid,
+      const PersonalizationKeys& keys);
+
   void SetState(PersonalizeStateId state) PW_LOCKS_EXCLUDED(lock_);
   void SetStateWithUid(PersonalizeStateId state,
+                       DetectedTagKind tag_kind,
                        const std::array<std::byte, 7>& uid,
                        size_t uid_size) PW_LOCKS_EXCLUDED(lock_);
   void SetError(std::string_view message) PW_LOCKS_EXCLUDED(lock_);
@@ -82,6 +92,10 @@ class PersonalizeCoordinator {
 
   pw::async2::CoroContext coro_cx_;
   std::optional<pw::async2::CoroOrElseTask> task_;
+
+  /// Tag arrival consumed by the awaiting-keys race; picked up by the main
+  /// loop on its next iteration. Only touched from the coroutine.
+  std::optional<nfc::NfcEvent> pending_event_;
 
   pw::sync::InterruptSpinLock lock_;
   PersonalizeSnapshot snapshot_ PW_GUARDED_BY(lock_);

--- a/maco_firmware/apps/personalize/screens/personalize_screen.cc
+++ b/maco_firmware/apps/personalize/screens/personalize_screen.cc
@@ -107,6 +107,13 @@ void PersonalizeScreen::UpdateStatusText(const PersonalizeSnapshot& snapshot) {
       status_text_ << "Tag personalized!\n";
       FormatUidTo(status_text_, snapshot.uid, snapshot.uid_size);
       break;
+    case PersonalizeStateId::kVerifying:
+      status_text_ << "Verifying tag...";
+      break;
+    case PersonalizeStateId::kVerified:
+      status_text_ << "Tag verified OK!\n";
+      FormatUidTo(status_text_, snapshot.uid, snapshot.uid_size);
+      break;
     case PersonalizeStateId::kError:
       status_text_ << "Error: ";
       status_text_ << snapshot.error_message;

--- a/maco_firmware/apps/personalize/screens/personalize_screen.h
+++ b/maco_firmware/apps/personalize/screens/personalize_screen.h
@@ -22,12 +22,23 @@ enum class PersonalizeStateId {
   kAwaitingTag,
   kPersonalizing,
   kPersonalized,
+  kVerifying,
+  kVerified,
   kError,
+};
+
+/// Identified type of the current tag, tracked alongside the state because
+/// polling clients usually miss the short-lived kFactoryTag/kMacoTag states.
+enum class DetectedTagKind {
+  kNone,
+  kFactory,
+  kMaco,
 };
 
 /// Snapshot of tag prober state for the UI thread.
 struct PersonalizeSnapshot {
   PersonalizeStateId state = PersonalizeStateId::kIdle;
+  DetectedTagKind tag_kind = DetectedTagKind::kNone;
   std::array<std::byte, 7> uid{};
   size_t uid_size = 0;
   pw::InlineString<128> error_message;

--- a/maco_firmware/apps/personalize/sdm_constants.cc
+++ b/maco_firmware/apps/personalize/sdm_constants.cc
@@ -80,4 +80,28 @@ pw::Result<NdefTemplate> BuildNdefTemplate(std::string_view base_url) {
   return result;
 }
 
+bool NdefContentMatches(pw::ConstByteSpan read_content,
+                        const NdefTemplate& expected) {
+  if (read_content.size() != expected.size) {
+    return false;
+  }
+
+  auto in_mirror_region = [&](size_t i) {
+    return (i >= expected.picc_data_offset &&
+            i < expected.picc_data_offset + kPiccDataHexLength) ||
+           (i >= expected.sdm_mac_offset &&
+            i < expected.sdm_mac_offset + kSdmMacHexLength);
+  };
+
+  for (size_t i = 0; i < expected.size; ++i) {
+    if (in_mirror_region(i)) {
+      continue;
+    }
+    if (read_content[i] != expected.data[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace maco::personalize::sdm

--- a/maco_firmware/apps/personalize/sdm_constants.h
+++ b/maco_firmware/apps/personalize/sdm_constants.h
@@ -33,6 +33,16 @@ constexpr uint8_t kNdefFileNumber = 0x02;
 /// Maximum bytes per plain-mode WriteData (limited by single frame).
 constexpr size_t kWriteChunkSize = 44;
 
+/// Maximum bytes per ReadData request (the driver does not support 91AF
+/// response chaining, so reads must stay within a single frame).
+constexpr size_t kReadChunkSize = 44;
+
+/// ASCII hex length of the SDM PICC data mirror (16 encrypted bytes).
+constexpr size_t kPiccDataHexLength = 32;
+
+/// ASCII hex length of the SDM MAC mirror (8 CMAC bytes).
+constexpr size_t kSdmMacHexLength = 16;
+
 /// Maximum supported base URL length (leaves room for NDEF overhead + SDM
 /// placeholders within 256-byte NDEF file limit).
 constexpr size_t kMaxBaseUrlLength = 64;
@@ -80,6 +90,16 @@ struct NdefTemplate {
 ///   [0x06]      0x04 (URI prefix = "https://")
 ///   [0x07-...]  base_url + "?picc=" + 32 zeros + "&cmac=" + 16 zeros
 pw::Result<NdefTemplate> BuildNdefTemplate(std::string_view base_url);
+
+/// Compare NDEF file content read back from a tag against the expected
+/// template, ignoring the two SDM mirror regions (PICC data + CMAC).
+///
+/// With SDM enabled the tag may substitute those regions at read time
+/// (encrypted PICC data / CMAC instead of the '0' placeholders), so their
+/// content carries no information about what was written — everything
+/// outside them must match byte-for-byte.
+bool NdefContentMatches(pw::ConstByteSpan read_content,
+                        const NdefTemplate& expected);
 
 /// Build ChangeFileSettings payload for enabling SDM with the given offsets.
 ///

--- a/maco_firmware/apps/personalize/sdm_constants_test.cc
+++ b/maco_firmware/apps/personalize/sdm_constants_test.cc
@@ -83,5 +83,51 @@ TEST(BuildNdefTemplate, RejectsEmptyAndOverlongBaseUrl) {
   EXPECT_FALSE(BuildNdefTemplate(too_long).ok());
 }
 
+TEST(NdefContentMatches, AcceptsIdenticalContent) {
+  auto result = BuildNdefTemplate(kBaseUrl);
+  ASSERT_TRUE(result.ok());
+  EXPECT_TRUE(NdefContentMatches(result->content(), *result));
+}
+
+// With SDM enabled the tag substitutes the PICC/CMAC mirror regions at read
+// time, so differences there must not fail verification.
+TEST(NdefContentMatches, IgnoresBothSdmMirrorRegions) {
+  auto result = BuildNdefTemplate(kBaseUrl);
+  ASSERT_TRUE(result.ok());
+  NdefTemplate read_back = *result;
+
+  for (size_t i = 0; i < kPiccDataHexLength; ++i) {
+    read_back.data[result->picc_data_offset + i] = std::byte{'A'};
+  }
+  for (size_t i = 0; i < kSdmMacHexLength; ++i) {
+    read_back.data[result->sdm_mac_offset + i] = std::byte{'F'};
+  }
+
+  EXPECT_TRUE(NdefContentMatches(read_back.content(), *result));
+}
+
+TEST(NdefContentMatches, RejectsDifferenceOutsideMirrorRegions) {
+  auto result = BuildNdefTemplate(kBaseUrl);
+  ASSERT_TRUE(result.ok());
+
+  // Corrupt one byte of the base URL (just after the 7-byte NDEF overhead).
+  NdefTemplate read_back = *result;
+  read_back.data[kNdefOverhead] = std::byte{'x'};
+  EXPECT_FALSE(NdefContentMatches(read_back.content(), *result));
+
+  // A byte between the mirror regions ("&cmac=" separator) must also count.
+  NdefTemplate read_back2 = *result;
+  read_back2.data[result->picc_data_offset + kPiccDataHexLength] =
+      std::byte{'#'};
+  EXPECT_FALSE(NdefContentMatches(read_back2.content(), *result));
+}
+
+TEST(NdefContentMatches, RejectsSizeMismatch) {
+  auto result = BuildNdefTemplate(kBaseUrl);
+  ASSERT_TRUE(result.ok());
+  EXPECT_FALSE(NdefContentMatches(
+      pw::ConstByteSpan(result->data.data(), result->size - 1), *result));
+}
+
 }  // namespace
 }  // namespace maco::personalize::sdm

--- a/maco_firmware/modules/nfc_tag/ntag424/ntag424_tag.cc
+++ b/maco_firmware/modules/nfc_tag/ntag424/ntag424_tag.cc
@@ -398,9 +398,16 @@ pw::async2::Coro<pw::Result<size_t>> Ntag424Tag::ReadData(
   }
   size_t total_bytes_read = 0;
 
-  // Increment CmdCtr for every successful command. The PICC always increments
-  // regardless of CommMode; we must stay in sync.
-  if (!sm->IncrementCounter()) {
+  // Increment CmdCtr only for session commands. A plain ReadData only ever
+  // succeeds against a file whose read access is free (Eh) — the PICC serves
+  // it OUTSIDE the secure session (same path as an unauthenticated phone
+  // tap: SDM mirroring applies and SDMReadCtr increments) and does NOT
+  // advance CmdCtr. Incrementing here anyway desyncs the session and makes
+  // the next MACed command fail its response-CMAC check.
+  // Note: WriteData increments unconditionally, which is correct while
+  // write access is key-gated; a plain write to a free-write file would
+  // have the mirror-image desync.
+  if (comm_mode != CommMode::kPlain && !sm->IncrementCounter()) {
     co_return pw::Status::ResourceExhausted();
   }
 
@@ -619,7 +626,7 @@ pw::async2::Coro<pw::Result<size_t>> Ntag424Tag::GetFileSettings(
   auto* sm = secure_messaging();
 
   // Build GetFileSettings command
-  // Full mode: 90 F5 00 00 09 [FileNo] [CMACt(8)] 00
+  // MAC mode:   90 F5 00 00 09 [FileNo] [CMACt(8)] 00
   // Plain mode: 90 F5 00 00 01 [FileNo] 00
   std::array<std::byte, 16> command;
   command[0] = std::byte{ntag424_cmd::kClaNative};
@@ -631,7 +638,7 @@ pw::async2::Coro<pw::Result<size_t>> Ntag424Tag::GetFileSettings(
 
   size_t cmd_len;
 
-  if (comm_mode == CommMode::kFull) {
+  if (comm_mode != CommMode::kPlain) {
     command[4] = std::byte{9};  // Lc: 1 (FileNo) + 8 (CMACt)
 
     // Build CMACt over command header (FileNo)
@@ -665,42 +672,37 @@ pw::async2::Coro<pw::Result<size_t>> Ntag424Tag::GetFileSettings(
     co_return InterpretStatusWord(sw1, sw2);
   }
 
-  // Increment CmdCtr for every successful command. The PICC always increments
-  // regardless of CommMode; we must stay in sync.
-  if (!sm->IncrementCounter()) {
+  // Increment CmdCtr only for session (MACed) commands; a plain
+  // GetFileSettings is served outside secure messaging and does not
+  // advance the counter (same rule as plain ReadData).
+  if (comm_mode != CommMode::kPlain && !sm->IncrementCounter()) {
     co_return pw::Status::ResourceExhausted();
   }
 
-  if (comm_mode == CommMode::kFull) {
-    // Response format: [EncryptedData(N)] [CMACt(8)] [SW(2)]
+  if (comm_mode != CommMode::kPlain) {
+    // GetFileSettings is a CommMode.MAC command: the response data is plain
+    // settings + CMACt, never encrypted. (Treating it as encrypted made the
+    // 19-byte SDM settings fail the decrypt's multiple-of-16 check, so this
+    // call silently failed for every SDM-enabled file.)
+    // Response format: [SettingsData(N)] [CMACt(8)] [SW(2)]
     size_t data_with_cmac_len = response_len - 2;
     if (data_with_cmac_len < 8) {
       co_return pw::Status::DataLoss();
     }
-    size_t encrypted_len = data_with_cmac_len - 8;
+    size_t data_len = data_with_cmac_len - 8;
 
-    pw::ConstByteSpan encrypted_data(response.data(), encrypted_len);
-    pw::ConstByteSpan received_cmac(response.data() + encrypted_len, 8);
+    pw::ConstByteSpan settings_data(response.data(), data_len);
+    pw::ConstByteSpan received_cmac(response.data() + data_len, 8);
 
     PW_CO_TRY(
-        sm->VerifyResponseCMACWithData(0x00, encrypted_data, received_cmac));
+        sm->VerifyResponseCMACWithData(0x00, settings_data, received_cmac));
 
-    std::array<std::byte, 32> decrypted;
-    if (encrypted_len > decrypted.size()) {
+    if (settings_buffer.size() < data_len) {
       co_return pw::Status::ResourceExhausted();
     }
-
-    size_t plaintext_len;
-    PW_CO_TRY(sm->DecryptResponseData(
-        encrypted_data, pw::ByteSpan(decrypted.data(), encrypted_len),
-        plaintext_len));
-
-    if (settings_buffer.size() < plaintext_len) {
-      co_return pw::Status::ResourceExhausted();
-    }
-    std::copy(decrypted.begin(), decrypted.begin() + plaintext_len,
+    std::copy(settings_data.begin(), settings_data.end(),
               settings_buffer.begin());
-    co_return plaintext_len;
+    co_return data_len;
 
   } else {
     // Plain mode: [SettingsData(N)] [SW(2)]

--- a/maco_firmware/modules/nfc_tag/ntag424/ntag424_tag.h
+++ b/maco_firmware/modules/nfc_tag/ntag424/ntag424_tag.h
@@ -156,22 +156,26 @@ class Ntag424Tag : public Iso14443Tag {
 
   /// Get file settings for a file.
   ///
-  /// The comm_mode must match the file's current CommMode setting:
-  /// - Plain: command has no CMAC, response is unencrypted
-  /// - Full: command includes CMAC, response is encrypted + MACed
+  /// GetFileSettings is a CommMode.MAC command per the NTAG424 datasheet:
+  /// in-session, the command carries a CMAC and the response is plain
+  /// settings data + CMAC — the data is never encrypted (unlike GetCardUid).
+  ///
+  /// - Plain: command has no CMAC, response is plain data; served outside
+  ///   secure messaging, so the session CmdCtr is not advanced
+  /// - Mac: command includes CMAC, response is plain data + CMAC
   ///
   /// @param cx Coroutine context for frame allocation
   /// @param session Proof token from Authenticate()
   /// @param file_number File number (0x01-0x03 for standard files)
   /// @param settings_buffer Buffer for settings (at least 32 bytes)
-  /// @param comm_mode Communication mode (must match file's CommMode)
+  /// @param comm_mode kMac in a session (default), kPlain outside one
   /// @return Coroutine resolving to number of settings bytes
   pw::async2::Coro<pw::Result<size_t>> GetFileSettings(
       pw::async2::CoroContext cx,
       const Ntag424Session& session,
       uint8_t file_number,
       pw::ByteSpan settings_buffer,
-      CommMode comm_mode = CommMode::kFull);
+      CommMode comm_mode = CommMode::kMac);
 
   /// Change file settings.
   ///

--- a/maco_firmware/protos/personalization_service.proto
+++ b/maco_firmware/protos/personalization_service.proto
@@ -12,7 +12,8 @@ service PersonalizationService {
   // Poll the current coordinator state (tag type, UID, status).
   rpc GetPersonalizeState(GetPersonalizeStateRequest) returns (GetPersonalizeStateResponse);
 
-  // Deliver pre-diversified keys for the current tag.
+  // Deliver pre-diversified keys for the current tag. Factory tags are
+  // personalized; MaCo tags are verified against the delivered keys.
   rpc PersonalizeTag(PersonalizeTagRequest) returns (PersonalizeTagResponse);
 }
 
@@ -25,6 +26,8 @@ message TagEvent {
     TAG_DEPARTED = 2;
     PERSONALIZATION_COMPLETE = 3;
     PERSONALIZATION_FAILED = 4;
+    VERIFICATION_COMPLETE = 5;
+    VERIFICATION_FAILED = 6;
   }
   enum TagType {
     TAG_UNKNOWN = 0;
@@ -60,10 +63,16 @@ message GetPersonalizeStateResponse {
     PERSONALIZING = 6;
     PERSONALIZED = 7;
     ERROR = 8;
+    VERIFYING = 9;
+    VERIFIED = 10;
   }
   State state = 1;
   bytes uid = 2;
   string error_message = 3;
+  // Identified type of the current tag. Carried independently of `state`
+  // because polling clients usually miss the short-lived FACTORY_TAG /
+  // MACO_TAG states.
+  TagEvent.TagType tag_type = 4;
 }
 
 message PersonalizeTagResponse {

--- a/tools/personalize_console.py
+++ b/tools/personalize_console.py
@@ -63,6 +63,24 @@ from pw_unit_test_proto import unit_test_pb2
 _LOG = logging.getLogger(__file__)
 
 
+class _StatePollLogFilter(logging.Filter):
+    """Drop routine RPC logs for the GetPersonalizeState poll.
+
+    The personalize pane polls GetPersonalizeState twice per second, and
+    pw_rpc logs every call start ("Starting PendingRpc(...)" on the
+    "pw_rpc" logger) and completion (on "pw_rpc.callback_client") —
+    flooding the host log window with pings. Suppress those below WARNING
+    so only actual actions (PersonalizeTag, tag events, errors) remain
+    visible. Logger filters only apply to records created on that exact
+    logger, so this must be installed on both loggers.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.WARNING:
+            return True
+        return "GetPersonalizeState" not in record.getMessage()
+
+
 class ReconnectingSerialClient:
     """Serial client with automatic reconnection on disconnect."""
 
@@ -506,6 +524,13 @@ def main() -> int:
         pw_cli.log.install(
             level=logging.DEBUG, use_color=False, log_file=logfile
         )
+
+        # Silence the 2/s state-poll pings; real actions still get logged.
+        state_poll_filter = _StatePollLogFilter()
+        for logger_name in ("pw_rpc", "pw_rpc.callback_client"):
+            logging.getLogger(logger_name).addFilter(state_poll_filter)
+        # asyncio's "Using selector: ..." startup line is DEBUG noise.
+        logging.getLogger("asyncio").setLevel(logging.INFO)
 
         with device_connection as device_client:
             personalize_pane = PersonalizePane(

--- a/tools/personalize_pane.py
+++ b/tools/personalize_pane.py
@@ -42,6 +42,12 @@ _STATE_AWAITING_KEYS = 5
 _STATE_PERSONALIZING = 6
 _STATE_PERSONALIZED = 7
 _STATE_ERROR = 8
+_STATE_VERIFYING = 9
+_STATE_VERIFIED = 10
+
+# Proto enum values for TagEvent.TagType
+_TAG_TYPE_FACTORY = 1
+_TAG_TYPE_MACO = 2
 
 _STATE_NAMES = {
     _STATE_IDLE: "idle",
@@ -53,15 +59,19 @@ _STATE_NAMES = {
     _STATE_PERSONALIZING: "personalizing",
     _STATE_PERSONALIZED: "personalized",
     _STATE_ERROR: "error",
+    _STATE_VERIFYING: "verifying",
+    _STATE_VERIFIED: "verified",
 }
 
 
 @dataclass
 class TagLogEntry:
-    """One personalization attempt in the scrolling log."""
+    """One personalization/verification attempt in the scrolling log."""
     uid_hex: str
     tag_type: str
-    status: str  # "pending", "personalizing", "ok", "fail", "skipped"
+    # "pending", "personalizing", "verifying", "ok", "verified", "fail",
+    # "skipped"
+    status: str
     message: str = ""
     timestamp: float = field(default_factory=time.monotonic)
 
@@ -223,11 +233,15 @@ class PersonalizePane(WindowPane, PluginMixin):
         uid_hex = uid.hex() if uid else ""
         error_msg = resp.error_message
 
+        # The response carries the identified tag type directly — polling
+        # usually misses the short-lived FACTORY_TAG/MACO_TAG states, so
+        # deriving the type from `state` would mislabel most tags.
         tag_type_str = {
-            _STATE_FACTORY_TAG: "factory",
-            _STATE_MACO_TAG: "maco",
-            _STATE_UNKNOWN_TAG: "unknown",
-        }.get(state, "")
+            _TAG_TYPE_FACTORY: "factory",
+            _TAG_TYPE_MACO: "maco",
+        }.get(resp.tag_type, "")
+        if not tag_type_str and state == _STATE_UNKNOWN_TAG:
+            tag_type_str = "unknown"
 
         with self._lock:
             prev = self._prev_state
@@ -268,10 +282,12 @@ class PersonalizePane(WindowPane, PluginMixin):
                 self._log.append(entry)
                 self._trim_log()
 
-            # Auto-personalize factory tags
+            # Auto-personalize factory tags / auto-verify MaCo tags. Both
+            # paths just deliver the diversified keys; the firmware decides
+            # (factory -> personalize, maco -> verify).
             if (state == _STATE_AWAITING_KEYS
                     and self._auto_mode
-                    and self._current_tag_type == "factory"):
+                    and self._current_tag_type in ("factory", "maco")):
                 uid_copy = uid
                 uid_hex_copy = uid_hex
                 # Release lock before RPC
@@ -290,6 +306,14 @@ class PersonalizePane(WindowPane, PluginMixin):
             self._current_uid = uid
             self._current_tag_type = "maco"
 
+        elif state == _STATE_VERIFYING:
+            self._update_last_entry(uid_hex, "verifying", "")
+
+        elif state == _STATE_VERIFIED:
+            self._update_last_entry(uid_hex, "verified", "")
+            self._current_uid = uid
+            self._current_tag_type = "maco"
+
         elif state == _STATE_ERROR:
             self._update_last_entry(uid_hex, "fail", error_msg)
 
@@ -300,7 +324,11 @@ class PersonalizePane(WindowPane, PluginMixin):
     def _do_personalize(self, uid: bytes, uid_hex: str) -> None:
         """Diversify keys and send PersonalizeTag RPC."""
         with self._lock:
-            self._update_last_entry(uid_hex, "personalizing", "")
+            status = (
+                "verifying" if self._current_tag_type == "maco"
+                else "personalizing"
+            )
+            self._update_last_entry(uid_hex, status, "")
 
         self.redraw_ui()
 
@@ -359,6 +387,7 @@ class PersonalizePane(WindowPane, PluginMixin):
             log_copy = list(self._log)
 
         ok_count = sum(1 for e in log_copy if e.status == "ok")
+        verified_count = sum(1 for e in log_copy if e.status == "verified")
         fail_count = sum(1 for e in log_copy if e.status == "fail")
 
         # Header
@@ -367,9 +396,14 @@ class PersonalizePane(WindowPane, PluginMixin):
         fragments.append(("class:theme-fg-cyan", "  Personalize"))
         fragments.append(("", "  "))
         fragments.append((mode_style, f"[{mode_str}]"))
-        if ok_count or fail_count:
+        if ok_count or verified_count or fail_count:
             fragments.append(("", "  "))
             fragments.append(("class:theme-fg-green", f"{ok_count} ok"))
+            if verified_count:
+                fragments.append(("", " / "))
+                fragments.append(
+                    ("class:theme-fg-cyan", f"{verified_count} verified")
+                )
             if fail_count:
                 fragments.append(("", " / "))
                 fragments.append(("class:theme-fg-red", f"{fail_count} fail"))
@@ -391,10 +425,17 @@ class PersonalizePane(WindowPane, PluginMixin):
             fragments.append(("bold", uid_hex))
             if current_state == _STATE_AWAITING_KEYS:
                 fragments.append(("", " "))
-                fragments.append(("class:theme-fg-yellow", "(press p)"))
+                hint = (
+                    "(press p to verify)" if current_tag_type == "maco"
+                    else "(press p)"
+                )
+                fragments.append(("class:theme-fg-yellow", hint))
             elif current_state == _STATE_PERSONALIZING:
                 fragments.append(("", " "))
                 fragments.append(("class:theme-fg-cyan", "(writing...)"))
+            elif current_state == _STATE_VERIFYING:
+                fragments.append(("", " "))
+                fragments.append(("class:theme-fg-cyan", "(verifying...)"))
             fragments.append(nl)
         else:
             fragments.append(("class:theme-fg-dim", f"  {state_name}"))
@@ -432,10 +473,12 @@ class PersonalizePane(WindowPane, PluginMixin):
         match status:
             case "pending":
                 return ".", ""
-            case "personalizing":
+            case "personalizing" | "verifying":
                 return "~", "class:theme-fg-cyan"
             case "ok":
                 return "\u2713", "class:theme-fg-green"
+            case "verified":
+                return "\u2713", "class:theme-fg-cyan"
             case "fail":
                 return "\u2717", "class:theme-fg-red"
             case "skipped":


### PR DESCRIPTION
## Summary

When a MaCo tag (terminal key authenticates on slot 1) is presented to the personalize firmware, it now runs a **read-only verification pass** instead of re-personalizing. The console delivers the diversified keys over the existing `PersonalizeTag` RPC; the firmware then checks:

- **All 5 key slots** — full 3-pass mutual `AuthenticateEV2First` per slot (order 1,2,3,4,0; the key-0 session is reused for the session-bound checks). NTAG424 has no auth-failure lockout, so probing is safe.
- **Random UID** — anticollision UID must be a 4-byte random ID (`0x08…`); there is no PICC-config readback.
- **Real UID** — authenticated `GetCardUid` vs. the UID used for key diversification.
- **SDM file settings** — `GetFileSettings` vs. `BuildSdmFileSettings` (existing `IsSdmConfigured` mapping).
- **NDEF template** — chunked read-back compared byte-for-byte outside the two SDM mirror regions (the free-access read is served via the SDM path like a phone tap, so mirrors carry live data and each verification consumes SDMReadCtr values).

Failures are reported per-check (e.g. `Key2, NDEF`) on the device screen, the event stream, and the console pane.

## Driver bugs found & fixed (verified on hardware)

- **`GetFileSettings` never worked in-session**: it is a CommMode.MAC command (response = plain settings + CMAC), but the driver decrypted the response — the 19-byte SDM settings failed the multiple-of-16 check and returned `InvalidArgument` silently. Both personalization call sites log-and-continue, so SDM verification during personalization has silently never run on real hardware. Now MAC-verified and copied; default comm mode renamed `kFull` → `kMac`.
- **`ReadData` desynced the session in plain mode**: plain reads only succeed against free-access (`Eh`) files, which the PICC serves *outside* the session (no CmdCtr advance, SDM mirroring applies). The driver incremented its local counter anyway, breaking the next MACed command's CMAC.

## Coordinator & console

- The awaiting-keys wait is now raced against the next NFC event (`KeysOrNfcEvent`, modeled on `async_util::ValueOrTimeout`) — previously a departing tag wedged the coordinator forever and all subsequent taps were ignored.
- New proto states `VERIFYING`/`VERIFIED`, events `VERIFICATION_COMPLETE`/`_FAILED`, and `GetPersonalizeStateResponse.tag_type` (polling misses the transient `FACTORY_TAG`/`MACO_TAG` states, so the pane previously mislabeled MaCo tags as factory).
- Console pane: `[maco]` labeling, "(press p to verify)" hint, auto mode also auto-verifies MaCo tags, separate verified counter; routine `GetPersonalizeState` poll logs are filtered below WARNING.
- ADR-0017 amended: the idempotent-reconfigure claim now only applies to factory tags; MaCo tags are verify-only by design.

## Validation

- `bazel test //maco_firmware/apps/personalize:sdm_constants_test //maco_firmware/modules/nfc_tag/ntag424:all` ✅ (incl. new `NdefContentMatches` tests)
- `./pw build p2` ✅
- On hardware: full verify flow green-path iterated with real tags (keys/UID/NDEF confirmed; `GetFileSettings` fix flashed, final confirmation pending)

## Review

`/code-review` ran clean (no blockers); its actionable findings (dead plain-mode inconsistency in `GetFileSettings`, dead coordinator branch, stale ADR-0017 claim) are fixed in this PR. Follow-ups noted for later: distinguish tag-removal from key-mismatch in verification reports, and a pre-existing uninitialized-buffer scan in `Authenticate`'s part-2 status handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)